### PR TITLE
Admin media

### DIFF
--- a/speedcenter/urls.py
+++ b/speedcenter/urls.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os.path
+
 from django.conf.urls.defaults import *
 from django.contrib import admin
 import settings
@@ -12,8 +14,11 @@ urlpatterns = patterns('',
 
 if settings.DEBUG:
     urlpatterns += patterns('',
-        (r'^media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
-        (r'^admin_media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': "/home/exarkun/.local/lib/python2.6/site-packages/django/contrib/admin/media"}),
+        (r'^media/(?P<path>.*)$', 'django.views.static.serve',
+         {'document_root': settings.MEDIA_ROOT}),
+        (r'^admin_media/(?P<path>.*)$', 'django.views.static.serve',
+         {'document_root':
+              os.path.join(os.path.dirname(admin.__file__), 'media')}),
     )
 urlpatterns += patterns('',
     (r'^', include('codespeed.urls')),


### PR DESCRIPTION
Everything at or below /admin-media/ is a 404 when the application is hosted in a WSGI container.  The branch gives this hierarchy the same treatment as the /media/ hierarchy is given.
