### PR TITLE
Benchmark description

### DIFF
--- a/speedcenter/codespeed/views.py
+++ b/speedcenter/codespeed/views.py
@@ -272,6 +272,7 @@ def gettimelinedata(request):
         timeline = {}
         timeline['benchmark'] = bench.name
         timeline['benchmark_id'] = bench.id
+        timeline['benchmark_description'] = bench.description
         timeline['units'] = bench.units
         lessisbetter = bench.lessisbetter and ' (less is better)' or ' (more is better)'
         timeline['lessisbetter'] = lessisbetter

--- a/speedcenter/templates/codespeed/timeline.html
+++ b/speedcenter/templates/codespeed/timeline.html
@@ -75,6 +75,7 @@
     }
     
     $("#plotgrid").html('<div id="plot"></div>');
+    $("#plotdescription").text(data['benchmark_description']);
     var plotoptions = 
     {
       title: {text: data['benchmark'], fontSize: '1.1em'},
@@ -311,5 +312,6 @@
 </div>
 <div id="content" class="clearfix">
 <div id="plotgrid"></div>
+<div id="plotdescription"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
The model and admin ui allow for descriptions of benchmarks, but this information is rendered nowhere user visible.  This branch adds a description to the timeline below the zoomed in plots (not the grid view).
