### PR TITLE
Infinite Loop in Report Creation

### DIFF
--- a/speedcenter/codespeed/models.py
+++ b/speedcenter/codespeed/models.py
@@ -322,7 +322,7 @@ class Report(models.Model):
             for bench in Benchmark.objects.filter(units=units['units']):
                 units_title = bench.units_title
                 lessisbetter = bench.lessisbetter
-                resultquery = result_list.filter(benchmark=bench)
+                resultquery = result_list.filter(benchmark=bench, value__gt=0)
                 if not len(resultquery): continue
 
                 resobj = resultquery.filter(benchmark=bench)[0]


### PR DESCRIPTION
Hi:

This is an old issue we already discussed before.

Currently, I run into infinite loops in the report creation if I have data which has benchmark values of <= 0.
The reason is your approach to calculate the significant digits. (line 404, see also line 376, 377)

Since I use -1 as value to indicate invalide results on the chart, I actually run into the issue.
However, since even 0 is an issue, this can be a serious problem.

Best regards
Stefan
