### PR TITLE
Provide a simple first version to retrieve some history from GitHub

### DIFF
--- a/speedcenter/codespeed/github.py
+++ b/speedcenter/codespeed/github.py
@@ -31,7 +31,6 @@ def updaterepo(project, update=True):
 def retrieve_revision(commit_id, username, project, revision = None):
     commit_url = 'http://github.com/api/v2/json/commits/show/%s/%s/%s' % (
         username, project, commit_id)
-    print commit_url
 
     commit_json = cache.get(commit_url)
 


### PR DESCRIPTION
This patch does a simple linear search on the first parent of every commit to find all commits for the changes view.
- this works for many cases but not all
- in case it does not walk the right path to a parent, it will terminate after 10 revisions
- should be 'good enough' for many cases
- better solutions still welcome
