### PR TITLE
Fix retrieving of data in changes view when linked from timeline

### DIFF
--- a/speedcenter/codespeed/views.py
+++ b/speedcenter/codespeed/views.py
@@ -605,7 +605,7 @@ def changes(request):
         commitid = data['rev']
         try:
             selectedrevision = Revision.objects.get(
-                commitid=commitid, branch__project=defaultexecutable.project
+                commitid__startswith=commitid, branch__project=defaultexecutable.project
             )
             if not selectedrevision in lastrevisions:
                 lastrevisions = list(chain(lastrevisions))


### PR DESCRIPTION
In the time line there are only short revision ids, thus, we should use a __startswith here to make sure we actually find the revision.
