### PR TITLE
Fix for urllib.urlencode({'revision_date': None}) for add_result

### DIFF
--- a/speedcenter/codespeed/tests.py
+++ b/speedcenter/codespeed/tests.py
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 
 
 class AddResultTest(TestCase):
+
     def setUp(self):
         self.path = reverse('speedcenter.codespeed.views.add_result')
         self.client = Client()
@@ -137,6 +138,14 @@ class AddResultTest(TestCase):
         # After adding a result for a second revision, a report should be created
         self.assertEquals(number_of_reports, 1)
 
+    def test_submit_data_with_none_timestamp(self):
+        """Test that add/result adds the result if date is set to the
+        string u"None". That happens while urlencode({'date': None})
+        """
+        modified_data = copy.deepcopy(self.data)
+        modified_data['revision_date'] = u"None"
+        response = self.client.post(self.path, modified_data)
+        self.assertEquals(response.status_code, 202)
 
 class AddJSONResultsTest(TestCase):
     def setUp(self):

--- a/speedcenter/codespeed/views.py
+++ b/speedcenter/codespeed/views.py
@@ -800,7 +800,7 @@ def save_result(data):
         rev = branch.revisions.get(commitid=data['commitid'])
     except Revision.DoesNotExist:
         rev_date = data.get("revision_date")
-        if not rev_date or rev_date == "":
+        if not rev_date or rev_date in ["", "None"]:
             rev_date = datetime.today()
         rev = Revision(branch=branch, commitid=data['commitid'], date=rev_date)
         try:


### PR DESCRIPTION
Hi,

On the mailing list a problem was reported using tools/save_single_result.py.
Problem is: In tools/save_single_result.py data['revision_date'] = None is assigned. urllib converts that into u"None". While saving the data a ValidationError: {'date': [u'Enter a valid date/time in YYYY-MM-DD HH:MM[:ss[.uuuuuu]] format.']} exception is thrown.

Not sure if my fix is the right way. It's a little brown paper bag style. One could argue that you should not set data['revision_date'] at all if there is no valid date string.

Also added a test for that.

It's time for a RESTful API ;-)

```
a8
```
