### PR TITLE
Fixed URL for static files other than /static

### DIFF
--- a/codespeed/static/css/main.css
+++ b/codespeed/static/css/main.css
@@ -4,7 +4,7 @@ body {
     margin: 0;
     padding: 0;
     background-color: #596A74;
-    background-image: url(/static/images/vgradient.png);
+    background-image: url(../images/vgradient.png);
     background-repeat: repeat-x;
     font-size: 16px;
     margin-bottom: 0.8em;
@@ -111,7 +111,7 @@ div#presentation div {
     vertical-align: middle;
 }
 div#presentation div.menubox {
-    background-image: url(/static/images/vgradient.png);
+    background-image: url(../images/vgradient.png);
     background-repeat: repeat-x;
     background-color: #FFFFFF;
     color: white;
@@ -131,13 +131,13 @@ div#presentation div.menubox:hover { border: 5px solid #FFCE9C; }
 div#presentation p { height: 5em; padding-left: 120px; }
 
 div#presentation div#changes p {
-    background: url(/static/images/changes.png) no-repeat;
+    background: url(../images/changes.png) no-repeat;
 }
 div#presentation div#timeline p {
-    background: url(/static/images/timeline.png) no-repeat;
+    background: url(../images/timeline.png) no-repeat;
 }
 div#presentation div#comparison p {
-    background: url(/static/images/comparison.png) no-repeat;
+    background: url(../images/comparison.png) no-repeat;
 }
 
 div#presentation div#reports { margin-top: 0.8em; }
@@ -311,7 +311,7 @@ table.tablesorter thead tr th {
     font-size: 8pt;
 }
 table.tablesorter thead tr th.header {
-    background-image: url(/static/images/bg.gif);
+    background-image: url(../images/bg.gif);
     background-repeat: no-repeat;
     background-position: center right;
     cursor: pointer;
@@ -337,10 +337,10 @@ table.tablesorter tbody tr.odd td {
     background-color:#F0F0F6;
 }
 table.tablesorter thead tr .headerSortUp {
-    background-image: url(/static/images/asc.gif);
+    background-image: url(../images/asc.gif);
 }
 table.tablesorter thead tr .headerSortDown {
-    background-image: url(/static/images/desc.gif);
+    background-image: url(../images/desc.gif);
 }
 table.tablesorter thead tr .headerSortDown, table.tablesorter thead tr .headerSortUp {
     background-color: #8dbdd8;
@@ -463,7 +463,7 @@ p.note, p.warning {
 }
 p.warning {
     padding-left: 42px;
-    background-image: url(/static/images/warning.png);
+    background-image: url(../images/warning.png);
 }
 p.note {
     margin-top: 20px;
@@ -473,7 +473,7 @@ p.note {
     -moz-box-shadow: 3px 3px 3px #888;
     -webkit-box-shadow: 3px 3px 3px #888;
     box-shadow: 3px 3px 3px #888;
-    background-image: url(/static/images/note.png);
+    background-image: url(../images/note.png);
 }
 
 div.footer {

--- a/codespeed/static/js/codespeed.js
+++ b/codespeed/static/js/codespeed.js
@@ -25,7 +25,7 @@ function getLoadText(text, h, showloader) {
     }
     loadtext += '<p' + pstyle + '>'+ text;
     if (showloader) {
-        loadtext += ' <img src="/static/images/ajax-loader.gif" align="bottom">';
+        loadtext += ' <img src="' + window.STATIC_URL +'images/ajax-loader.gif" align="bottom">';
     }
     loadtext += '</p></div>';
     return loadtext;

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -6,6 +6,9 @@
     <meta name="keywords" content="performance, test, interpreter, plots, charts">
     <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <link href="{{ STATIC_URL }}css/main.css" rel="stylesheet" type="text/css">
+    <script type='text/javascript'>
+        var STATIC_URL = '{{ STATIC_URL }}';
+    </script>
     <script type="text/javascript" src="{{ STATIC_URL }}js/codespeed.js"></script>
     <script type="text/javascript" src="{{ STATIC_URL }}js/jquery-1.6.2.min.js"></script>
     {% block extra_head %}{% endblock %}


### PR DESCRIPTION
```
- settings.STATIC_URL can be used to configure where static files are
  That was broken in static css an js scripts
- css uses relative links url('../foo.gif')
- js uses the global variable STATIC_URL set in base.html
```

That fixes issues when the static files (images, js, css) are served from an URL other than /static.
