### PR TITLE
The benchmark name missed the surrounding quotes.

### DIFF
--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -294,8 +294,8 @@
 
     //Set default selected benchmark
     $("input:radio[name='benchmark']")
-        .filter('[value=' + valueOrDefault(event.parameters['ben'],
-                                           '{{ defaultbenchmark }}') + ']')
+        .filter('[value=\"' + valueOrDefault(event.parameters['ben'],
+                                           '{{ defaultbenchmark }}') + '\"]')
         .attr('checked', true);
 
     //Set default selected environment


### PR DESCRIPTION
- there might be the need to urlencode that stuff also, or to switch to ids, but actually I like those URLs which tell me more than just an id a lot better
- think, this is a BC break in jQuery, might hit us elsewhere, too.

This should close #64
