### PR TITLE
Added DEF_BRANCH as option and used it on the timeline

### DIFF
--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -371,8 +371,8 @@ def gettimelinedata(request):
         }
         # Temporary
         trunks = []
-        if Branch.objects.filter(name='default'):
-            trunks.append('default')
+        if Branch.objects.filter(name=settings.DEF_BRANCH):
+            trunks.append(settings.DEF_BRANCH)
         #for branch in data2.get('bran', '').split(','): #-- For now, we'll only work with trunk branches
         append = False
         for branch in trunks:
@@ -475,7 +475,7 @@ def timeline(request):
 
     defaultbranch = ""
     if "default" in branch_list:
-        defaultbranch = "default"
+        defaultbranch = settings.DEF_BRANCH
     if data.get('bran') in branch_list:
         defaultbranch = data.get('bran')
 
@@ -626,7 +626,7 @@ def changes(request):
     # Get lastest revisions for this project and it's "default" branch
     lastrevisions = Revision.objects.filter(
         branch__project=defaultexecutable.project,
-        branch__name="default"
+        branch__name=settings.DEF_BRANCH
     ).order_by('-date')[:revlimit]
     if not len(lastrevisions):
         return no_data_found(request)
@@ -684,7 +684,7 @@ def reports(request):
 
     return render_to_response('codespeed/reports.html', {
         'reports': Report.objects.filter(
-            revision__branch__name='default'
+            revision__branch__name=settings.DEF_BENCHMARK
         ).order_by('-revision__date')[:10],
     }, context_instance=RequestContext(request))
 

--- a/example/settings.py
+++ b/example/settings.py
@@ -172,3 +172,7 @@ STATIC_ROOT = os.path.join(BASEDIR, "sitestatic")
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
 
+DEF_BRANCH = "default" # Defines the default branch to be used.
+                       # In git projects, this branch is usually be calles
+                       # "master"
+DEF_BRANCH = "master"


### PR DESCRIPTION
This patch allows to view results of the `master` branch in git easily without using `default` as a name (I do not like to have to use different names for the same thing).
It also avoids confusion in the compare view, since master is still called master, while `default` would be removed as branch name.

I noticed that you are kind of opposed such a change, but I find it handy to be able to chose a branch to be shown on the timeline. Actually, I would like to see all/some branches on the timeline in the end, but this is a start.

For user convenience and robustness, we might need to consider to use some default value hardcode in the app and not in the user-edited settings.py (https://docs.djangoproject.com/en/dev/topics/settings/#custom-default-settings). That might also be a good idea for the other options, and could avoid the several checks litered around them.

Let me know what you think, it is not a big deal, just handy.

Thanks
Stefan
