### PR TITLE
Problem with Django + Python's clone during report generation? (not reliably reproducible)

### DIFF
--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -288,7 +288,7 @@ class Report(models.Model):
             ).order_by('-date')[:trend_depth+1]
             # Same as self.revision unless in a different branch
             lastrevision = lastrevisions[0]
-        except IndexError, Exception, e:
+        except:
             return []
         change_list = []
         pastrevisions = []


### PR DESCRIPTION
Hi:

I ran into an issue where the django query failed for some reason, deep inside a stack trace which ended with the standard clone failing because some `__init__` function expected 4 arguments instead of 1.

I was not able to look further into this, it might be some django related problem, but I applied this quick-fix, and since then I do not have 500 errors reported by my benchmarking client anymore.

Not sure whether this fix should be applied.

Actually, it might be better to make sure that when a report fails for some reason at least the data that got submitted is saved, and failing to create a report does not lead to lost data.

Best regards
Stefan
