### PR TITLE
Fix lookup of Revisions() in displaylogs()

### DIFF
--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -701,7 +701,7 @@ def displaylogs(request):
     error = False
     try:
         startrev = Revision.objects.filter(
-            branch=rev.branch.project
+            branch=rev.branch
         ).filter(date__lt=rev.date).order_by('-date')[:1]
         if not len(startrev):
             startrev = rev


### PR DESCRIPTION
Hi,

I hope the commit msg explains it. I run into the issue while using projects w/ different SCM. SVN commit ids don't work in git :-)

```
- views.displaylogs() looks for the oldest rev of the rev.branch.
  Bug was that the filter looked for branch=rev.branch.project. Thus,
  the look up was Branch.objects.get(pk=rev.branch.project).
  It has to be Branch.objects.get(pk=rev.branch).
```

BTW, wouldn't it be better to limit the number of last commit msg that get displayed? Well, I prepare a patch and make it configurable next week.

Thanks,

```
a8
```
