### PR TITLE
one line fix to make IE not fail completely in timeline view

### DIFF
--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -200,7 +200,7 @@
           renderer:$.jqplot.DateAxisRenderer,
           pad: 1.01,
           autoscale:true,
-          showTicks: false,
+          showTicks: false
         }
       },
       highlighter: {show:false},


### PR DESCRIPTION
Just removed ',' of last element in JS dict. Internet Explorer failed there, I was told ;-).
