### PR TITLE
Add option to control display of authors email address, close #32

### DIFF
--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -29,6 +29,9 @@ DEF_EXECUTABLE = None # Executable that should be chosen as default in the chang
                       # Given as the name of the executable.
                       # Example: defaultexecutable = "myexe"
 
+SHOW_AUTHOR_EMAIL_ADDRESS = True # Whether to show the authors email address in the
+                                 # changes log
+
 ## Timeline view options ##
 DEF_BENCHMARK = None   # Default selected benchmark. Possible values:
                        #   None: will show a grid of plot thumbnails, or a

--- a/codespeed/templates/codespeed/changes_logs.html
+++ b/codespeed/templates/codespeed/changes_logs.html
@@ -13,7 +13,7 @@
                     </ul>
                 {% endif %}
 
-                {% if log.author_email %}
+                {% if log.author_email and show_email_address %}
                     <a class="author fn" href="mailto:{{ log.author_email }}">{{ log.author }}</a>
                 {% else %}
                     <span class="author fn">{{ log.author }}</span>

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -720,7 +720,8 @@ def displaylogs(request):
         error = repr(e)
 
     return render_to_response('codespeed/changes_logs.html',
-                                {'error': error, 'logs': logs },
+                                {'error': error, 'logs': logs,
+                                 'show_email_address': settings.SHOW_AUTHOR_EMAIL_ADDRESS},
                                 context_instance=RequestContext(request))
 
 

--- a/example/settings.py
+++ b/example/settings.py
@@ -144,6 +144,9 @@ WEBSITE_NAME = "MySpeedSite" # This name will be used in the reports RSS feed
                       # Given as the name of the executable.
                       # Example: defaultexecutable = "myexe"
 
+#SHOW_AUTHOR_EMAIL_ADDRESS = True # Whether to show the authors email address in the
+                                 # changes log
+
 ## Timeline view options ##
 #DEF_BENCHMARK = "grid" # Default selected benchmark. Possible values:
                        #   "grid": will show the grid of plots


### PR DESCRIPTION
Use SHOW_AUTHOR_EMAIL_ADDRESS to show or hide the email addresses in the
changes view.
