### PR TITLE
Move working copy handling from git/mercurial into project model

### DIFF
--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import simplejson as json
@@ -25,6 +27,24 @@ class Project(models.Model):
 
     def __unicode__(self):
         return self.name
+
+    @property
+    def repo_name(self):
+        # name not defined for None, GitHub or Subversion
+        if self.repo_type in ('N', 'H', 'S'):
+            error = 'Not supported for %s project' % self.get_repo_type_display()
+            raise AttributeError(error)
+
+        return os.path.splitext(self.repo_path.split(os.sep)[-1])[0]
+
+    @property
+    def working_copy(self):
+        # working copy exists for mercurial and git only
+        if self.repo_type in ('N', 'H', 'S'):
+            error = 'Not supported for %s project' % self.get_repo_type_display()
+            raise AttributeError(error)
+
+        return os.path.join(settings.REPOSITORY_BASE_PATH, self.repo_name)
 
 
 class Branch(models.Model):

--- a/codespeed/tests/tests.py
+++ b/codespeed/tests/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
-import copy, json
+import copy, json, os
 
 from django.test import TestCase
 from django.test.client import Client
@@ -375,3 +375,26 @@ class CodespeedSettings(TestCase):
         for k in self.cs_setting_keys:
             self.assertEqual(getattr(settings, k), getattr(default_settings, k))
 
+
+class ProjectTest(TestCase):
+    """Test project model
+    """
+
+    def setUp(self):
+        self.github_project = Project(repo_type='H', repo_path='https://github.com/tobami/codespeed.git')
+        self.git_project = Project(repo_type='G', repo_path='/home/foo/codespeed')
+
+    def test_repo_name(self):
+        """Test that only projects with local repositories have a repo_name attribute
+        """
+        self.assertEqual(self.git_project.repo_name, 'codespeed')
+
+        self.assertRaises(AttributeError, getattr, self.github_project, 'repo_name')
+
+    def test_working_copy(self):
+        """Test that only projects with local repositories have a working_copy attribute
+        """
+        self.assertEqual(self.git_project.working_copy,
+                         os.path.join(settings.REPOSITORY_BASE_PATH, self.git_project.repo_name))
+
+        self.assertRaises(AttributeError, getattr, self.github_project, 'working_copy')


### PR DESCRIPTION
An attempt to clean this part up a bit. I'm not sure how to handle access to `repo_name` and `working_copy` on repository types that don't support it, should it raise an exception?
