### PR TITLE
Update response codes to match the latest version of django-tastypie.

### DIFF
--- a/codespeed/tests/tests_api.py
+++ b/codespeed/tests/tests_api.py
@@ -79,6 +79,9 @@ class EnvironmentTest(FixtureTestCase):
         for k, v in self.env2_data.items():
             self.assertEqual(
                 json.loads(response.content)[k], v)
+        response = self.client.delete('/api/v1/environment/3/',
+                                    content_type='application/json')
+        self.assertEquals(response.status_code, 204)
 
     def test_put(self):
         """Should modify an existing environment"""
@@ -96,12 +99,17 @@ class EnvironmentTest(FixtureTestCase):
 
     def test_delete(self):
         """Should delete an environment"""
-        response = self.client.delete('/api/v1/environment/3/',
+        response = self.client.delete('/api/v1/environment/1/',
                                     content_type='application/json')
-        self.assertEquals(response.status_code, 410)
+        self.assertEquals(response.status_code, 204)
 
-        response = self.client.get('/api/v1/environment/3/')
-        self.assertEquals(response.status_code, 410)
+        response = self.client.get('/api/v1/environment/1/')
+        self.assertEquals(response.status_code, 404)
+
+    def test_nonexistent(self):
+        """Requesting an environment that doesn't exist should return a 404"""
+        response = self.client.get('/api/v1/environment/3333333/')
+        self.assertEquals(response.status_code, 404)
 
 
 class UserTest(FixtureTestCase):


### PR DESCRIPTION
When I run tests on the current master I get the following error, this changes fixes the error by updating the response codes to match the latest version of django-tastypie and improves the tests by not relying on a previous test to create environment 3.
# 

FAIL: test_delete (codespeed.tests.tests_api.EnvironmentTest)
## Should delete an environment

Traceback (most recent call last):
  File "/home/michaelt/git/codespeed/codespeed/tests/tests_api.py", line 101, in test_delete
    self.assertEquals(response.status_code, 410)
AssertionError: 404 != 410

---
