### PR TITLE
Fix to only treat IE < 9 special for excanvas.min.js

### DIFF
--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -2,7 +2,7 @@
 {% block title %}{{ block.super }}: Timeline{% endblock %}
 {% block extra_head %}
 {{ block.super }}
-<!--[if IE]><script language="javascript" type="text/javascript" src="{{ STATIC_URL }}js/jqplot/excanvas.min.js"></script><![endif]-->
+<!--[if lt IE 9]><script language="javascript" type="text/javascript" src="{{ STATIC_URL }}js/jqplot/excanvas.min.js"></script><![endif]-->
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}js/jqplot/jquery.jqplot.min.css" />
 <script type="text/javascript" src="{{ STATIC_URL }}js/jquery.address-1.4.min.js?autoUpdate=0"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}js/jqplot/jquery.jqplot.min.js"></script>


### PR DESCRIPTION
Hi,

Sorry again for the other pull request that was not supposed to be on top of the api stuff.

Here is the right one on top of master.
