### PR TITLE
Permit to toggle show of benchmarks and executables in comparison

### DIFF
--- a/codespeed/static/css/main.css
+++ b/codespeed/static/css/main.css
@@ -226,6 +226,7 @@ div.about_content { text-align: left; }
 .boxbody input { margin-left: 0; vertical-align: top; }
 #options li { margin-bottom: 0.8em; }
 .seriescolor { float: right; margin-top: 2px; height: 13px; width: 14px; }
+a.togglefold { font-size: normal; color: #000000; }
 a.checkall, a.uncheckall { font-size: small; color: #AAAAAA; }
 
 p.errormessage { line-height: 10em; margin-bottom: 10em; }

--- a/codespeed/static/js/codespeed.js
+++ b/codespeed/static/js/codespeed.js
@@ -43,4 +43,12 @@ $(function() {
             return false;
         });
     });
+
+    $('.togglefold').each(function() {
+        var lis = $(this).parent().children("li");
+        $(this).click(function() {
+            lis.slideToggle();
+            return false;
+        });
+    });
 });

--- a/codespeed/templates/codespeed/comparison.html
+++ b/codespeed/templates/codespeed/comparison.html
@@ -28,7 +28,7 @@
   <div class="boxhead"><h2>Executables</h2></div>
   <div class="boxbody">
     {% for proj, executable in executables.items %}
-    <ul>{{ proj }} <a href="#" class="checkall">(All</a>, <a href="#" class="uncheckall">None)</a>
+    <ul><a href="#" class="togglefold">{{ proj }}</a> <a href="#" class="checkall">(All</a>, <a href="#" class="uncheckall">None)</a>
     {% for exe in executable %}
       <li title="{{ exe.executable }} - {{ exe.revision }}">
         <input id="exe_{{ exe.key }}" type="checkbox" name="executables" value="{{ exe.key }}" />
@@ -41,7 +41,7 @@
   <div class="boxhead"><h2>Benchmarks</h2></div>
   <div class="boxbody">
   {% for key,benchlist in benchmarks.items %}
-  <ul>{{ key }} <a href="#" class="checkall">(All</a>, <a href="#" class="uncheckall">None)</a>
+  <ul><a href="#" class="togglefold">{{ key }}</a> <a href="#" class="checkall">(All</a>, <a href="#" class="uncheckall">None)</a>
     {% for bench in benchlist|dictsort:"name" %}
     <li title="{{ bench.description }}">
       <input id="benchmark_{{ bench.id }}" type="checkbox" name="benchmarks" value="{{ bench.id }}" />


### PR DESCRIPTION
This branch add a new feature which consists on tool benchmarks and executables lists in comparison.
