### PR TITLE
Add in ability to set Benchmark data if it's first being created

### DIFF
--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -894,6 +894,19 @@ def save_result(data):
     branch, created = Branch.objects.get_or_create(name=data["branch"],
                                                    project=p)
     b, created = Benchmark.objects.get_or_create(name=data["benchmark"])
+
+    if created:
+        if "description" in data:
+            b.description = data["description"]
+        if "units" in data:
+            b.units = data["units"]
+        if "units_title" in data:
+            b.units_title = data["units_title"]
+        if "lessisbetter" in data:
+            b.lessisbetter = data["lessisbetter"]
+        b.full_clean()
+        b.save()
+
     try:
         rev = branch.revisions.get(commitid=data['commitid'])
     except Revision.DoesNotExist:


### PR DESCRIPTION
I noticed that supplying the data for the benchmark when submitting data didn't set these fields, it's nice to be able to do this from the client side, but I also thought it wasn't a good idea to let clients do this after they've already been set.  Let me know what you think!
