### PR TITLE
Set requirements to something that will yield a working setup in a clean env.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Django>=1.4
+Django==1.5.5
 South<=2.0
 isodate==0.4.8
 django-tastypie==0.10.0
+mimeparse


### PR DESCRIPTION
I was struggling quite a bit to find a working combination of things, and this selection of versions seems to do the trick.

It's restrictive, but perhaps good to keep around in case other people not familiar with these frameworks also try to setup Codespeed. I failed with Django 1.4, and 1.6. From the 1.5 line, other versions might work as well. And mimeparse wasn't a requirement before, but was a missing import.
