### PR TITLE
Removed django-tastypie from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version='0.9.1',
     url='https://github.com/tobami/codespeed',
     license='GNU Lesser General Public License version 2.1',
-    install_requires=['django>=1.4', 'isodate', 'south<=2.0', 'django-tastypie'],
+    install_requires=['django>=1.4', 'isodate', 'south<=2.0'],
     packages=find_packages(exclude=['ez_setup', 'sample_project']),
     description='A web application to monitor and analyze the performance of your code',
     include_package_data=True,


### PR DESCRIPTION
This was missing from the tastypie removal commit.
