### PR TITLE
Change date formatting from just str() to isodate()

### DIFF
--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -437,7 +437,7 @@ def gettimelinedata(request):
                         std_dev = res.std_dev
                     results.append(
                         [
-                            str(res.revision.date), res.value, std_dev,
+                            res.revision.date.isoformat(), res.value, std_dev,
                             res.revision.get_short_commitid(), branch
                         ]
                     )


### PR DESCRIPTION
Allows for better browser compatibility.  Specifically, Firefox on OSX and Iceweasel on Debian don't render timeline plots properly without this change, because Firefox doesn't parse dates the same way.  This ISO formatting parses more reliably.  Kudos to @magistere for the fix.
