### PR TITLE
Better SVN error message.

### DIFF
--- a/codespeed/subversion.py
+++ b/codespeed/subversion.py
@@ -33,9 +33,8 @@ def getlogs(newrev, startrev):
                     pysvn.opt_revision_kind.number, newrev.commitid
                 )
             )
-    except pysvn.ClientError:
-        raise RuntimeError(
-            "Could not resolve '" + newrev.branch.project.repo_path + "'")
+    except pysvn.ClientError as e:
+        raise RuntimeError(e.args)
     except ValueError:
         raise RuntimeError(
             "'%s' is an invalid subversion revision number" % newrev.commitid)


### PR DESCRIPTION
Error messages reported by Pysvn are usually quite good. They easily allow to 
understand the issue and then fix it. Codespeed swallows this nice error
message to replace it by a generic one hiding what was wrong.

For example is anonymous users are not allowed, you will never be able to
figure it out with the "Could not resolve" message.

It seems better to expose the reported error as is rather than trying to
"improve" it.
