### PR TITLE
Remove @require_GET from getcommitlog

### DIFF
--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -789,7 +789,6 @@ def displaylogs(request):
         context_instance=RequestContext(request))
 
 
-@require_GET
 def getcommitlogs(rev, startrev, update=False):
     logs = []
 


### PR DESCRIPTION
As it is not a view. Fixes #175.
