### PR TITLE
codespeed doesn't work with Django 1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.4
+Django>=1.4,<1.7
 South<=2.0
 isodate==0.4.8


### PR DESCRIPTION
Otherwise fails with:

```
File "/home/kmod/codespeed_env/local/lib/python2.7/site-packages/south/models.py", line 8, in <module>
    raise RuntimeError("South does not support Django 1.7 or higher. Please use native Django migrations.")
RuntimeError: South does not support Django 1.7 or higher. Please use native Django migrations.
```
