### PR TITLE
Get mercurial logs for non-default branches

### DIFF
--- a/codespeed/mercurial.py
+++ b/codespeed/mercurial.py
@@ -45,8 +45,7 @@ def getlogs(endrev, startrev):
     updaterepo(endrev.branch.project, update=False)
 
     cmd = ["hg", "log",
-            "-r", "%s:%s" % (endrev.commitid, startrev.commitid),
-            "-b", "default",
+            "-r", "%s::%s" % (startrev.commitid, endrev.commitid),
             "--template", "{rev}:{node|short}\n{node}\n{author|user}\n{author|email}\n{date}\n{desc}\n=newlog=\n"]
 
     working_copy = endrev.branch.project.working_copy


### PR DESCRIPTION
When POSTing a benchmark result to /result/add/ for a mercurial project with a changeset on a branch other than default, codespeed fails with KeyError('author').

This changeset fixes getlogs() for mercurial repositories to work for branches other than default.