### PR TITLE
Add support for displaying median benchmarks

### DIFF
--- a/codespeed/admin.py
+++ b/codespeed/admin.py
@@ -37,9 +37,10 @@ admin.site.register(Executable, ExecutableAdmin)
 
 
 class BenchmarkAdmin(admin.ModelAdmin):
-    list_display = ('name', 'benchmark_type', 'description', 'units_title',
-                    'units', 'lessisbetter', 'default_on_comparison')
-    list_filter = ('lessisbetter',)
+    list_display = ('name', 'benchmark_type', 'data_type', 'description',
+                    'units_title', 'units', 'lessisbetter',
+                    'default_on_comparison')
+    list_filter = ('data_type','lessisbetter')
     ordering = ['name']
     search_fields = ('name', 'description')
 

--- a/codespeed/migrations/0002_median.py
+++ b/codespeed/migrations/0002_median.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('codespeed', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='benchmark',
+            name='data_type',
+            field=models.CharField(default='U', max_length=1, choices=[('U', 'Mean'), ('M', 'Median')]),
+        ),
+        migrations.AddField(
+            model_name='result',
+            name='q1',
+            field=models.FloatField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='result',
+            name='q3',
+            field=models.FloatField(null=True, blank=True),
+        ),
+    ]

--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -146,6 +146,10 @@ class Benchmark(models.Model):
         ('C', 'Cross-project'),
         ('O', 'Own-project'),
     )
+    D_TYPES = (
+        ('U', 'Mean'),
+        ('M', 'Median'),
+    )
 
     name = models.CharField(unique=True, max_length=100)
     parent = models.ForeignKey(
@@ -153,6 +157,7 @@ class Benchmark(models.Model):
         help_text="allows to group benchmarks in hierarchies",
         null=True, blank=True, default=None)
     benchmark_type = models.CharField(max_length=1, choices=B_TYPES, default='C')
+    data_type = models.CharField(max_length=1, choices=D_TYPES, default='U')
     description = models.CharField(max_length=300, blank=True)
     units_title = models.CharField(max_length=30, default='Time')
     units = models.CharField(max_length=20, default='seconds')
@@ -188,6 +193,8 @@ class Result(models.Model):
     std_dev = models.FloatField(blank=True, null=True)
     val_min = models.FloatField(blank=True, null=True)
     val_max = models.FloatField(blank=True, null=True)
+    q1 = models.FloatField(blank=True, null=True)
+    q3 = models.FloatField(blank=True, null=True)
     date = models.DateTimeField(blank=True, null=True)
     revision = models.ForeignKey(Revision, related_name="results")
     executable = models.ForeignKey(Executable, related_name="results")

--- a/codespeed/results.py
+++ b/codespeed/results.py
@@ -122,6 +122,8 @@ def save_result(data):
     r.std_dev = data.get('std_dev')
     r.val_min = data.get('min')
     r.val_max = data.get('max')
+    r.q1 = data.get('q1')
+    r.q3 = data.get('q3')
 
     r.full_clean()
     r.save()

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -66,3 +66,5 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          # COMP_EXECUTABLES = [
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
+
+USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view

--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -83,6 +83,16 @@
     <input id="equidistant" name="equidistant" type="checkbox" />
     <label for="equidistant">Equidistant</label>
   </span>
+  {% if use_median_bands %}
+  <span class="options median" title="Shows quartile bands in the plots" style="display: none">
+    <input id="show_quartile_bands" type="checkbox" name="show_quartile_bands" checked="checked"/>
+    <label for="show_quartile_bands">Show quartile bands</label>
+  </span>
+  <span class="options median" title="Shows extrema bands in the plots" style="display: none">
+    <input id="show_extrema_bands" type="checkbox" name="show_extrema_bands" checked="checked"/>
+    <label for="show_extrema_bands">Show extrema bands</label>
+  </span>
+  {% endif %}
   <a id="permalink" href="#">Permalink</a>
 </div>
 <div id="content" class="clearfix">
@@ -115,7 +125,9 @@
       branches: [{% for b in branch_list %}"{{ branch }}", {% endfor %}],
       benchmark: "{{ defaultbenchmark }}",
       environment: {{ defaultenvironment.id }},
-      equidistant: "{{ defaultequid }}"
+      equidistant: "{{ defaultequid }}",
+      quartiles: "{{ defaultquarts }}",
+      extrema: "{{ defaultextr }}"
     });
   });
 </script>


### PR DESCRIPTION
Includes:
- A new type field to benchmarks to distinguish between mean and median data.
- New result fields for storing Q1 and Q3.
- Toggles for displaying quartile and extrema bands on median benchmarks.

See [this graph](https://speed.z.cash/timeline/?exe=1&base=none&ben=time+solveequihash&env=1&revs=10&equid=off&quarts=on&extr=on) for an example.