### PR TITLE
Allow defining different default branches for different projects

### DIFF
--- a/codespeed/feeds.py
+++ b/codespeed/feeds.py
@@ -38,12 +38,11 @@ class LatestEntries(ResultFeed):
     description = "Last benchmark runs"
 
     def result_filter(self):
-        return Q(revision__branch__name=settings.DEF_BRANCH)
+        return Report.default_filter()
 
 
 class LatestSignificantEntries(ResultFeed):
     description = "Last benchmark runs with significant changes"
 
     def result_filter(self):
-        return Q(revision__branch__name=settings.DEF_BRANCH,
-                 colorcode__in=('red', 'green'))
+        return Report.significant_default_filter()

--- a/codespeed/feeds.py
+++ b/codespeed/feeds.py
@@ -1,7 +1,6 @@
 from django.contrib.syndication.views import Feed
 from codespeed.models import Report
 from django.conf import settings
-from django.db.models import Q
 
 
 class ResultFeed(Feed):

--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -555,13 +555,12 @@ class Report(models.Model):
     @staticmethod
     def default_filter():
         default_branch = settings.DEF_BRANCH[None]
-        explicit = reduce(
-            lambda q1,q2: q1 | q2,
-            [Q(revision__branch__name=settings.DEF_BRANCH[projectname],
-               revision__project__name=projectname) for projectname in settings.DEF_BRANCH.keys()])
-        implicit = Q(revision__branch__name=default_branch) & (reduce(
-            lambda q1,q2: q1 & q2,
-            [~Q(revision__project__name=projectname) for projectname in settings.DEF_BRANCH.keys()]))
+        explicit = Q()
+        implicit = Q(revision__branch__name=default_branch)
+        for projectname in settings.DEF_BRANCH.keys():
+            explicit |= Q(revision__branch__name=settings.DEF_BRANCH[projectname],
+                          revision__project__name=projectname)
+            implicit &= ~Q(revision__project__name=projectname)
         return explicit | implicit
 
     @staticmethod

--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.db import models
+from django.db.models import Q
 from django.utils.encoding import python_2_unicode_compatible
 
 from .commits.github import GITHUB_URL_RE
@@ -552,7 +553,7 @@ class Report(models.Model):
         return json.loads(self._tablecache)
 
     @staticmethod
-    def default_filter(self):
+    def default_filter():
         default_branch = settings.DEF_BRANCH[None]
         explicit = reduce(
             lambda q1,q2: q1 | q2,
@@ -564,5 +565,5 @@ class Report(models.Model):
         return explicit | implicit
 
     @staticmethod
-    def significant_default_filter(self):
-        return self.reports_filter() & Q(colorcode__in=('red', 'green'))
+    def significant_default_filter():
+        return Report.reports_filter() & Q(colorcode__in=('red', 'green'))

--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -557,7 +557,7 @@ class Report(models.Model):
         default_branch = settings.DEF_BRANCH[None]
         explicit = reduce(
             lambda q1,q2: q1 | q2,
-            [Q(revision__branch__name=settings.DEF_BRANCH[name],
+            [Q(revision__branch__name=settings.DEF_BRANCH[projectname],
                revision__project__name=projectname) for projectname in settings.DEF_BRANCH.keys()])
         implicit = Q(revision__branch__name=default_branch) & (reduce(
             lambda q1,q2: q1 & q2,
@@ -566,4 +566,4 @@ class Report(models.Model):
 
     @staticmethod
     def significant_default_filter():
-        return Report.reports_filter() & Q(colorcode__in=('red', 'green'))
+        return Report.default_filter() & Q(colorcode__in=('red', 'green'))

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -6,9 +6,11 @@ WEBSITE_NAME = "MySpeedSite" # This name will be used in the reports RSS feed
 
 DEF_ENVIRONMENT = None #Name of the environment which should be selected as default
 
-DEF_BRANCH = "default" # Defines the default branch to be used.
-                       # In git projects, this branch is usually be calles
-                       # "master"
+from collections import defaultdict
+DEF_BRANCH = defaultdict(lambda: "default") # Defines the default branch to be used.
+                                            # In git projects, this branch is usually 'master'
+                                            # The dictionary can return different branches
+                                            # per project name
 
 DEF_BASELINE = None # Which executable + revision should be default as a baseline
                     # Given as the name of the executable and commitid of the revision

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -251,6 +251,11 @@ def gettimelinedata(request):
         exeid, revid = data['base'].split("+")
         baselinerev = Revision.objects.get(id=revid)
         baselineexe = Executable.objects.get(id=exeid)
+    # Temporary
+    trunkquery = reduce(
+        lambda q1, q2: q1 | q2,
+        [Q(name=settings.DEF_BRANCH[p.name], project=p) for p in Project.objects.all()])
+    trunks = Branch.objects.filter(trunkquery)
     for bench in benchmarks:
         lessisbetter = bench.lessisbetter and ' (less is better)' or ' (more is better)'
         timeline = {
@@ -263,15 +268,11 @@ def gettimelinedata(request):
             'branches':              {},
             'baseline':              "None",
         }
-        # Temporary
-        trunks = []
-        if Branch.objects.filter(name=settings.DEF_BRANCH):
-            trunks.append(settings.DEF_BRANCH)
         # For now, we'll only work with trunk branches
         append = False
         for branch in trunks:
             append = False
-            timeline['branches'][branch] = {}
+            timeline['branches'][branch.name] = {}
             for executable in executables:
                 resultquery = Result.objects.filter(
                     benchmark=bench
@@ -280,7 +281,9 @@ def gettimelinedata(request):
                 ).filter(
                     executable=executable
                 ).filter(
-                    revision__branch__name=branch
+                    revision__branch__name=branch.name
+                ).filter(
+                    revision__project__name=branch.project.name
                 ).select_related(
                     "revision"
                 ).order_by('-revision__date')[:number_of_revs]
@@ -306,7 +309,7 @@ def gettimelinedata(request):
                             [
                                 res.revision.date.strftime('%Y/%m/%d %H:%M:%S %z'),
                                 res.value, val_max, q3, q1, val_min,
-                                res.revision.get_short_commitid(), branch
+                                res.revision.get_short_commitid(), branch.name
                             ]
                         )
                     else:
@@ -317,10 +320,10 @@ def gettimelinedata(request):
                             [
                                 res.revision.date.strftime('%Y/%m/%d %H:%M:%S %z'),
                                 res.value, std_dev,
-                                res.revision.get_short_commitid(), branch
+                                res.revision.get_short_commitid(), branch.name
                             ]
                         )
-                timeline['branches'][branch][executable] = results
+                timeline['branches'][branch.name][executable] = results
                 append = True
             if baselinerev is not None and append:
                 try:
@@ -336,9 +339,9 @@ def gettimelinedata(request):
                     # determine start and end revision (x axis)
                     # from longest data series
                     results = []
-                    for exe in timeline['branches'][branch]:
-                        if len(timeline['branches'][branch][exe]) > len(results):
-                            results = timeline['branches'][branch][exe]
+                    for exe in timeline['branches'][branch.name]:
+                        if len(timeline['branches'][branch.name][exe]) > len(results):
+                            results = timeline['branches'][branch.name][exe]
                     end = results[0][0]
                     start = results[len(results) - 1][0]
                     timeline['baseline'] = [
@@ -395,7 +398,7 @@ def timeline(request):
 
     defaultbranch = ""
     if "default" in branch_list:
-        defaultbranch = settings.DEF_BRANCH
+        defaultbranch = settings.DEF_BRANCH[defaultproject.name]
     if data.get('bran') in branch_list:
         defaultbranch = data.get('bran')
 
@@ -569,7 +572,7 @@ def changes(request):
     for proj in Project.objects.filter(track=True):
         executables[proj] = Executable.objects.filter(project=proj)
         projectlist.append(proj)
-        branch = Branch.objects.filter(name=settings.DEF_BRANCH, project=proj)
+        branch = Branch.objects.filter(name=settings.DEF_BRANCH[proj.name], project=proj)
         revisionlists[proj.name] = list(Revision.objects.filter(
             branch=branch
         ).order_by('-date')[:revlimit])
@@ -625,13 +628,12 @@ def reports(request):
 
     context['reports'] = \
         Report.objects.filter(
-            revision__branch__name=settings.DEF_BRANCH
+            Report.default_filter()
         ).order_by('-revision__date')[:10]
 
     context['significant_reports'] = \
         Report.objects.filter(
-            revision__branch__name=settings.DEF_BRANCH,
-            colorcode__in=('red', 'green')
+            Report.significant_default_filter()
         ).order_by('-revision__date')[:10]
 
     return render_to_response('codespeed/reports.html', context,

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -253,9 +253,9 @@ def gettimelinedata(request):
         baselinerev = Revision.objects.get(id=revid)
         baselineexe = Executable.objects.get(id=exeid)
     # Temporary
-    trunkquery = reduce(
-        lambda q1, q2: q1 | q2,
-        [Q(name=settings.DEF_BRANCH[p.name], project=p) for p in Project.objects.all()])
+    trunkquery = Q()
+    for p in Project.objects.all():
+        trunkquery |= Q(name=settings.DEF_BRANCH[p.name], project=p)
     trunks = Branch.objects.filter(trunkquery)
     for bench in benchmarks:
         lessisbetter = bench.lessisbetter and ' (less is better)' or ' (more is better)'


### PR DESCRIPTION
On speed.squeak.org we track two git repositories, for one of which 'master' is the default and for the other 'Cog' is the default development branch. But the second project also has a 'master' branch that we also integrate into and that should be track. But for comparisons on the timeline and for the changes feed, we want 'Cog' for one and 'master' for the other.

This PR breaks older settings.py files. If that is not desirable, I guess we can be more careful when getting the DEF_BRANCH
