### PR TITLE
Use template markers for 'Home' and 'About' links

### DIFF
--- a/codespeed/templates/codespeed/base.html
+++ b/codespeed/templates/codespeed/base.html
@@ -14,7 +14,7 @@
       {# TODO: Rename id=title to id=header and/or switch to <header> #}
       <div id="title" class="clearfix">
         {% block page_header %}
-          <a href="/">
+        <a href="{% url 'home' %}">
           {% block logo %}
             <img src="{{ STATIC_URL }}images/logo.png" height="48" alt="logo"/>
           {% endblock logo %}
@@ -22,7 +22,7 @@
           <h2>{% block page_title %}SPEED CENTER{% endblock page_title %}</h2>
           {% block top_nav %}
             <ul id="links" class="inline">
-              <li><a href="/">Home</a></li><li><a href="../about/">About</a></li>
+                <li><a href="{% url 'home' %}">Home</a></li><li><a href="{% url 'about' %}">About</a></li>
             </ul>
           {% endblock top_nav %}
         {% endblock page_header %}

--- a/codespeed/urls.py
+++ b/codespeed/urls.py
@@ -6,8 +6,8 @@ from codespeed.feeds import LatestEntries, LatestSignificantEntries
 
 
 urlpatterns = patterns('',
-    url(r'^$', TemplateView.as_view(template_name='home.html')),
-    url(r'^about/$', TemplateView.as_view(template_name='about.html')),
+    url(r'^$', TemplateView.as_view(template_name='home.html'), name='home'),
+    url(r'^about/$', TemplateView.as_view(template_name='about.html'), name='about'),
     # RSS for reports
     url(r'^feeds/latest/$', LatestEntries(), name='latest_feeds'),
     url(r'^feeds/latest_significant/$', LatestSignificantEntries(),


### PR DESCRIPTION
Instead of hard-coding the links to the 'Home' page and to the 'About' page,
use template markers.  This allows the hyperlinks to work even if the Codespeed
site does not reside at the web server root.