### PR TITLE
Add the 'makeimage' service

### DIFF
--- a/codespeed/images.py
+++ b/codespeed/images.py
@@ -1,0 +1,70 @@
+import cStringIO
+from matplotlib.figure import Figure
+from matplotlib.ticker import FormatStrFormatter
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+DEF_CHART_W = 600
+DEF_CHART_H = 500
+
+MIN_CHART_W = 400
+MIN_CHART_H = 300
+
+
+def gen_image_from_results(result_data, width, height):
+    canvas_width = width if width is not None else DEF_CHART_W
+    canvas_height = height if height is not None else DEF_CHART_H
+
+    canvas_width = max(canvas_width, MIN_CHART_W)
+    canvas_height = max(canvas_height, MIN_CHART_H)
+
+    values = [element.value for element in result_data['results']]
+
+    max_value = max(values)
+    min_value = min(values)
+    value_range = max_value - min_value
+    range_increment = 0.05 * abs(value_range)
+
+    fig = Figure(figsize=(canvas_width / 100, canvas_height / 100), dpi=100)
+    ax = fig.add_axes([.1, .15, .85, .75])
+    ax.set_ylim(min_value - range_increment, max_value + range_increment)
+
+    xax = range(0, len(values))
+    yax = values
+
+    ax.set_xticks(xax)
+    ax.set_xticklabels([element.date.strftime('%d %b') for element in
+                       result_data['results']], rotation=75)
+    ax.set_title(result_data['benchmark'].name)
+
+    if result_data['relative']:
+        ax.yaxis.set_major_formatter(FormatStrFormatter('%.2f%%'))
+
+    font_sizes = [16, 16]
+    dimensions = [canvas_width, canvas_height]
+
+    for idx, value in enumerate(dimensions):
+        if value < 500:
+            font_sizes[idx] = 8
+        elif value < 1000:
+            font_sizes[idx] = 12
+    
+    if result_data['relative']:
+        font_sizes[0] -= 2
+
+    for item in ax.get_yticklabels():
+        item.set_fontsize(font_sizes[0])
+
+    for item in ax.get_xticklabels():
+        item.set_fontsize(font_sizes[1])
+
+    ax.title.set_fontsize(font_sizes[1] + 4)
+
+    ax.scatter(xax, yax)
+    ax.plot(xax, yax)
+
+    canvas = FigureCanvasAgg(fig)
+    buf = cStringIO.StringIO()
+    canvas.print_png(buf)
+    buf_data = buf.getvalue()
+
+    return buf_data

--- a/codespeed/images.py
+++ b/codespeed/images.py
@@ -1,4 +1,4 @@
-import cStringIO
+from io import BytesIO
 from matplotlib.figure import Figure
 from matplotlib.ticker import FormatStrFormatter
 from matplotlib.backends.backend_agg import FigureCanvasAgg
@@ -63,7 +63,7 @@ def gen_image_from_results(result_data, width, height):
     ax.plot(xax, yax)
 
     canvas = FigureCanvasAgg(fig)
-    buf = cStringIO.StringIO()
+    buf = BytesIO()
     canvas.print_png(buf)
     buf_data = buf.getvalue()
 

--- a/codespeed/urls.py
+++ b/codespeed/urls.py
@@ -23,6 +23,7 @@ urlpatterns += patterns('codespeed.views',
     url(r'^timeline/json/$', 'gettimelinedata', name='gettimelinedata'),
     url(r'^comparison/$', 'comparison', name='comparison'),
     url(r'^comparison/json/$', 'getcomparisondata', name='getcomparisondata'),
+    url(r'^makeimage/$', 'makeimage', name='makeimage'),
 )
 
 urlpatterns += patterns('codespeed.views',

--- a/codespeed/validators.py
+++ b/codespeed/validators.py
@@ -6,7 +6,7 @@ def validate_results_request(data):
     Validates that a result request dictionary has all needed parameters
     and their type is correct.
 
-    Throws ValidationError on error
+    Throws ValidationError on error.
     """
     mandatory_data = [
         'env',
@@ -24,12 +24,23 @@ def validate_results_request(data):
             raise ValidationError('Value for key "' + key +
                                   '" empty in GET request!')
 
-    # Check that 'revs' is the correct format (if it exists)
-    if 'revs' in data:
-        try:
-            rev_value = int(data['revs'])
-        except ValueError:
-            raise ValidationError('Value for key "revs" is not an integer!')
-        if rev_value <= 0:
-            raise ValidationError('Value for key "revs" should be a'
-                                  ' strictly positive integer!', True)
+    integer_data = [
+            'revs',
+            'width',
+            'height'
+    ]
+
+    """
+    Check that the items in integer_data are the correct format,
+    if they exist
+    """
+    for key in integer_data:
+        if key in data:
+            try:
+                rev_value = int(data[key])
+            except ValueError:
+                raise ValidationError('Value for "' + key +
+                                      '" is not an integer!')
+            if rev_value <= 0:
+                raise ValidationError('Value for "' + key + '" should be a'
+                                      ' strictly positive integer!')

--- a/codespeed/validators.py
+++ b/codespeed/validators.py
@@ -1,0 +1,35 @@
+from django.core.exceptions import ValidationError
+
+
+def validate_results_request(data):
+    """
+    Validates that a result request dictionary has all needed parameters
+    and their type is correct.
+
+    Throws ValidationError on error
+    """
+    mandatory_data = [
+        'env',
+        'proj',
+        'branch',
+        'exe',
+        'ben',
+    ]
+
+    for key in mandatory_data:
+        if key not in data:
+            raise ValidationError('Key "' + key +
+                                  '" missing from GET request!')
+        elif data[key] == '':
+            raise ValidationError('Value for key "' + key +
+                                  '" empty in GET request!')
+
+    # Check that 'revs' is the correct format (if it exists)
+    if 'revs' in data:
+        try:
+            rev_value = int(data['revs'])
+        except ValueError:
+            raise ValidationError('Value for key "revs" is not an integer!')
+        if rev_value <= 0:
+            raise ValidationError('Value for key "revs" should be a'
+                                  ' strictly positive integer!', True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=1.6,<1.9
 isodate>=0.4.7,<0.6
+matplotlib>=1.4.3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     download_url="https://github.com/tobami/codespeed/tags",
     license='GNU Lesser General Public License version 2.1',
     keywords=["benchmarking", "visualization"],
-    install_requires=['django>=1.6,<1.9', 'isodate>=0.4.7,<0.6'],
+    install_requires=['django>=1.6,<1.9', 'isodate>=0.4.7,<0.6', 'matplotlib>=1.4.3'],
     packages=find_packages(exclude=['ez_setup', 'sample_project']),
     description='A web application to monitor and analyze the performance of your code',
     include_package_data=True,


### PR DESCRIPTION
This adds a service for generating chart images based on the latest
benchmark results using the matplotlib module.
The URL for this service is /sample_project/makeimage/.
The image can be directly embedded in any HTML document using
<img src="host_name/sample_project/makeimage/?...> or simply accessed
using the same URL.

The mandatory GET params are:
env -	the environment's name
proj -	the project's name
branch -the branch's name
exe -	the executable's name
ben -	the benchmark's name
The following params are optional:
revs -	positive integer, number of results the image will display.
	revs=10 is the implicit value representing that the latest 10
	results will be displayed on the chart
relative - if '1' or 'yes', instead of displaying absolute values,
	the first value from the series is used as a baseline and
	the chart will display percentual increments from that baseline
base_commit - specifies a commit name to be used as a baseline instead
	of the first value of the series
base_env - the environment's name to be used for the base_commit instead
	of env
base_proj - the project's name to be used for the base_commit instead
	of proj
base_exe - the executable's name to be use for the base_commit instead of
	exe