### PR TITLE
Added http basic authentication to results resources

### DIFF
--- a/codespeed/__init__.py
+++ b/codespeed/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'codespeed.apps.CodespeedConfig'

--- a/codespeed/apps.py
+++ b/codespeed/apps.py
@@ -1,0 +1,18 @@
+from django.apps import AppConfig
+from django.conf import settings
+
+
+class CodespeedConfig(AppConfig):
+    name = 'codespeed'
+
+    def ready(self):
+        import warnings
+        if settings.ALLOW_ANONYMOUS_POST:
+            warnings.warn("Results can be posted by unregistered users")
+            warnings.warn(
+                "In the future anonymous posting will be disabled by default",
+                category=FutureWarning)
+        elif not settings.REQUIRE_SECURE_AUTH:
+            warnings.warn(
+                "REQUIRE_SECURE_AUTH is not True. This server may prompt for"
+                " user credentials to be submitted in plaintext")

--- a/codespeed/auth.py
+++ b/codespeed/auth.py
@@ -1,0 +1,33 @@
+import logging
+from functools import wraps
+from django.contrib.auth import authenticate
+from django.http import HttpResponse, HttpResponseForbidden
+from base64 import b64decode
+
+
+def basic_auth_required(realm='default'):
+    def _helper(func):
+        @wraps(func)
+        def _decorator(request, *args, **kwargs):
+            if 'HTTP_AUTHORIZATION' in request.META:
+                http_auth = request.META['HTTP_AUTHORIZATION']
+                authmeth, auth = http_auth.split(' ', 1)
+                if authmeth.lower() == 'basic':
+                    authb = b64decode(auth.strip())
+                    auth = authb.decode()
+                    username, password = auth.split(':', 1)
+                    user = authenticate(username=username, password=password)
+                    if user is not None:
+                        logging.info(
+                            'Authentication succeeded for {}'.format(username))
+                        return func(request, *args, **kwargs)
+                    else:
+                        return HttpResponseForbidden()
+            res = HttpResponse()
+            res.status_code = 401
+            res.reason_phrase = 'Unauthorized'
+            res['WWW-Authenticate'] = 'Basic realm="{}"'.format(realm)
+            return res
+        return _decorator
+
+    return _helper

--- a/codespeed/auth.py
+++ b/codespeed/auth.py
@@ -1,6 +1,6 @@
 import logging
 from functools import wraps
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, login
 from django.http import HttpResponse, HttpResponseForbidden
 from django.conf import settings
 from base64 import b64decode
@@ -24,9 +24,10 @@ def basic_auth_required(realm='default'):
                 if authmeth.lower() == 'basic':
                     username, password = decode_basic_auth(auth)
                     user = authenticate(username=username, password=password)
-                    if user is None:
+                    if user is not None and user.is_active:
                         logging.info(
                             'Authentication succeeded for {}'.format(username))
+                        login(request, user)
                         allowed = True
                     else:
                         return HttpResponseForbidden()

--- a/codespeed/auth.py
+++ b/codespeed/auth.py
@@ -5,21 +5,24 @@ from django.http import HttpResponse, HttpResponseForbidden
 from django.conf import settings
 from base64 import b64decode
 
+__ALL__ = ['basic_auth_required']
+
 
 def basic_auth_required(realm='default'):
     def _helper(func):
         @wraps(func)
         def _decorator(request, *args, **kwargs):
             allowed = False
+            logging.info('request is secure? {}'.format(request.is_secure()))
             if settings.ALLOW_ANONYMOUS_POST:
                 allowed = True
             elif 'HTTP_AUTHORIZATION' in request.META:
+                if settings.REQUIRE_SECURE_AUTH and not request.is_secure():
+                    return insecure_connection_response()
                 http_auth = request.META['HTTP_AUTHORIZATION']
                 authmeth, auth = http_auth.split(' ', 1)
                 if authmeth.lower() == 'basic':
-                    authb = b64decode(auth.strip())
-                    auth = authb.decode()
-                    username, password = auth.split(':', 1)
+                    username, password = decode_basic_auth(auth)
                     user = authenticate(username=username, password=password)
                     if user is None:
                         logging.info(
@@ -29,11 +32,25 @@ def basic_auth_required(realm='default'):
                         return HttpResponseForbidden()
             if allowed:
                 return func(request, *args, **kwargs)
-            res = HttpResponse()
-            res.status_code = 401
-            res.reason_phrase = 'Unauthorized'
-            res['WWW-Authenticate'] = 'Basic realm="{}"'.format(realm)
-            return res
+
+            if settings.REQUIRE_SECURE_AUTH and not request.is_secure():
+                return insecure_connection_response()
+            else:
+                res = HttpResponse()
+                res.status_code = 401
+                res.reason_phrase = 'Unauthorized'
+                res['WWW-Authenticate'] = 'Basic realm="{}"'.format(realm)
+                return res
         return _decorator
 
     return _helper
+
+
+def insecure_connection_response():
+    return HttpResponseForbidden('Secure connection required')
+
+
+def decode_basic_auth(auth):
+    authb = b64decode(auth.strip())
+    auth = authb.decode()
+    return auth.split(':', 1)

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -68,3 +68,6 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          #     ('myexe', 'L'),]
 
 USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
+
+
+ALLOW_ANONYMOUS_POST = False  # Whether anonymous users be allowed to post results

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -70,4 +70,4 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
 USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 
-ALLOW_ANONYMOUS_POST = False  # Whether anonymous users be allowed to post results
+ALLOW_ANONYMOUS_POST = True  # Whether anonymous users be allowed to post results

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -70,5 +70,5 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
 USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 
-ALLOW_ANONYMOUS_POST = False  # Whether anonymous users can post results
+ALLOW_ANONYMOUS_POST = True  # Whether anonymous users can post results
 REQUIRE_SECURE_AUTH = True  # Whether auth needs to be over a secure channel

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -70,4 +70,5 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
 USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 
-ALLOW_ANONYMOUS_POST = True  # Whether anonymous users be allowed to post results
+ALLOW_ANONYMOUS_POST = False  # Whether anonymous users can post results
+REQUIRE_SECURE_AUTH = True  # Whether auth needs to be over a secure channel

--- a/codespeed/tests/test_views.py
+++ b/codespeed/tests/test_views.py
@@ -3,13 +3,14 @@ from datetime import datetime, timedelta
 import copy
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.urlresolvers import reverse
 
 from codespeed.models import (Project, Benchmark, Revision, Branch, Executable,
                               Environment, Result, Report)
 
 
+@override_settings(ALLOW_ANONYMOUS_POST=True)
 class TestAddResult(TestCase):
 
     def setUp(self):
@@ -162,6 +163,7 @@ class TestAddResult(TestCase):
             response.content.decode(), "Result data saved successfully")
 
 
+@override_settings(ALLOW_ANONYMOUS_POST=True)
 class TestAddJSONResults(TestCase):
 
     def setUp(self):
@@ -361,6 +363,7 @@ class TestTimeline(TestCase):
             [u'2011/04/13 17:04:22 ', 2000.0, 1.11111, u'2', u'', u'default'])
 
 
+@override_settings(ALLOW_ANONYMOUS_POST=True)
 class TestReports(TestCase):
 
     def setUp(self):

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -14,6 +14,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.csrf import csrf_exempt
 from django.template import RequestContext
 from django.conf import settings
+from .auth import basic_auth_required
 
 from .models import (Environment, Report, Project, Revision, Result,
                      Executable, Benchmark, Branch)
@@ -697,6 +698,7 @@ def displaylogs(request):
 
 @csrf_exempt
 @require_POST
+@basic_auth_required('results')
 def add_result(request):
     response, error = save_result(request.POST)
     if error:
@@ -710,6 +712,7 @@ def add_result(request):
 
 @csrf_exempt
 @require_POST
+@basic_auth_required('results')
 def add_json_results(request):
     if not request.POST.get('json'):
         return HttpResponseBadRequest("No key 'json' in POST payload")


### PR DESCRIPTION
This PR is intended to resolve #34 .

HTTP Basic Auth is enabled for the `results/add` and `results/add/json` resources using a decorator. I also included a check for `request.is_secure`, conditioned on a setting so it's easier to test in deployment. Tests get an override to turn the setting off.

I added two settings, REQUIRE_SECURE_AUTH as mentioned above, and ALLOW_ANONYMOUS_POST to toggle the auth check.