### PR TITLE
Sizing the baseline selector to fit in its container

### DIFF
--- a/codespeed/static/css/timeline.css
+++ b/codespeed/static/css/timeline.css
@@ -1,0 +1,3 @@
+select#baseline {
+    width: 100%;
+}

--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -4,6 +4,7 @@
 
 {% block extra_head %}
 {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}/css/timeline.css" />
   <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}js/jqplot/jquery.jqplot.min.css" />
 {% endblock %}
 


### PR DESCRIPTION
Without setting the width, the selector extends beyond the side panel it sits in.

![20170418220713_scrot-1366x712](https://cloud.githubusercontent.com/assets/1487560/25161692/18445874-2483-11e7-87de-e00d9c6d3b3c.png)
