### PR TITLE
Made git tag identification more conservative

### DIFF
--- a/codespeed/commits/git.py
+++ b/codespeed/commits/git.py
@@ -68,7 +68,7 @@ def getlogs(endrev, startrev):
 
         tag = ""
 
-        cmd = ["git", "describe", "--tags", commit_id]
+        cmd = ["git", "tag", "--points-at", commit_id]
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, cwd=working_copy)
 
         try:


### PR DESCRIPTION
This changes the behavior of `git` projects to only identify a commit as being tagged when a tag points at the specific commit.

Currently, virtually every commit will be shown as tagged. This makes it difficult to pick out specific commits (e.g., a previous release) as points of comparison in the comparisons view. For what it's worth, the `github` repos already perform the same way.