### PR TITLE
Use the correct data array pos for commit ID in timeline changes permalinks

### DIFF
--- a/codespeed/static/js/timeline.js
+++ b/codespeed/static/js/timeline.js
@@ -69,7 +69,7 @@ function permalinkToChanges(commitid, executableid, environment) {
 function OnMarkerClickHandler(ev, gridpos, datapos, neighbor, plot) {
   if($("input[name='benchmark']:checked").val() === "grid") { return false; }
   if (neighbor) {
-    var commitid = neighbor.data[neighbor.data.length-2];
+    var commitid = neighbor.data[neighbor.data.length-3];
     // Get executable ID from the seriesindex array
     var executableid = seriesindex[neighbor.seriesIndex];
     var environment = $("input[name='environments']:checked").val();


### PR DESCRIPTION
Fixes a bug introduced in 8fb7f1f373c6095cf16e386a12f3accb96acaa64.