### PR TITLE
Customise the meta description to describe the URL

### DIFF
--- a/codespeed/templates/codespeed/base.html
+++ b/codespeed/templates/codespeed/base.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{% block title %}MyProject's Speed Center{% endblock %}</title>
-    <meta name="description" content="A performance analysis tool for software projects. It shows performance regresions and allows comparing different applications or implementations">
+    <meta name="description" content="{% block description %}A performance analysis tool for software projects. It shows performance regresions and allows comparing different applications or implementations{% endblock %}">
     <meta name="keywords" content="performance, test, plots, charts">
     <meta charset="UTF-8">
     <link href="{{ STATIC_URL }}css/main.css" rel="stylesheet" type="text/css">

--- a/codespeed/templates/codespeed/changes.html
+++ b/codespeed/templates/codespeed/changes.html
@@ -1,6 +1,7 @@
 {% extends "codespeed/base_site.html" %}
 
 {% block title %}{{ block.super }}: Changes{% endblock %}
+{% block description %}{% if pagedesc %}{{ pagedesc }}{% else %}{{ block.super }}{% endif %}{% endblock %}
 
 {% block navigation %}
     {{ block.super }}

--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -1,6 +1,7 @@
 {% extends "codespeed/base_site.html" %}
 
 {% block title %}{{ block.super }}: Timeline{% endblock %}
+{% block description %}{% if pagedesc %}{{ pagedesc }}{% else %}{{ block.super }}{% endif %}{% endblock %}
 
 {% block extra_head %}
 {{ block.super }}

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -463,11 +463,17 @@ def timeline(request):
         defaultextr = "on"
 
     # Information for template
+    if defaultbenchmark in ['grid', 'show_none']:
+        pagedesc = None
+    else:
+        pagedesc = "Results timeline for the '%s' benchmark (project %s)" % \
+            (defaultbenchmark, defaultproject)
     executables = {}
     for proj in Project.objects.filter(track=True):
         executables[proj] = Executable.objects.filter(project=proj)
     use_median_bands = hasattr(settings, 'USE_MEDIAN_BANDS') and settings.USE_MEDIAN_BANDS
     return render_to_response('codespeed/timeline.html', {
+        'pagedesc': pagedesc,
         'checkedexecutables': checkedexecutables,
         'defaultbaseline': defaultbaseline,
         'baseline': baseline,
@@ -611,7 +617,10 @@ def changes(request):
         ]
     revisionlists = json.dumps(revisionlists)
 
+    pagedesc = "Report of %s performance changes for commit %s on branch %s" % \
+        (defaultexecutable, selectedrevision.commitid, selectedrevision.branch)
     return render_to_response('codespeed/changes.html', {
+        'pagedesc': pagedesc,
         'defaultenvironment': defaultenv,
         'defaultexecutable': defaultexecutable,
         'selectedrevision': selectedrevision,


### PR DESCRIPTION
This is useful when pasting permalinks into apps that show the description in a summary of the page.