### PR TITLE
fixtures/testdata: set value for "default_branch" project fields

### DIFF
--- a/codespeed/fixtures/testdata.json
+++ b/codespeed/fixtures/testdata.json
@@ -9,7 +9,8 @@
             "repo_user": "", 
             "track": true, 
             "repo_pass": "", 
-            "repo_path": ""
+            "repo_path": "",
+            "default_branch": "default"
         }
     }, 
     {
@@ -22,7 +23,8 @@
             "repo_user": "", 
             "track": true, 
             "repo_pass": "", 
-            "repo_path": ""
+            "repo_path": "",
+            "default_branch": "default"
         }
     }, 
     {
@@ -35,7 +37,8 @@
             "repo_user": "", 
             "track": false, 
             "repo_pass": "", 
-            "repo_path": ""
+            "repo_path": "",
+            "default_branch": "default"
         }
     }, 
     {


### PR DESCRIPTION
With this change, "Timeline" and "Changes" are rendered with
testdata as one might expect.

Fixes #238.
