### PR TITLE
Return empty string from github commits

### DIFF
--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -66,10 +66,14 @@ def retrieve_tag(commit_id, username, project):
     tags_url = 'https://api.github.com/repos/%s/%s/git/refs/tags' % (
         username, project)
 
+    ## TODO: This might not do what is intended
+    ##   the tag SHA isn't the same thing as the commit it points
     tags_json = fetch_json(tags_url)
     for tag in tags_json:
         if tag['object']['sha'] == commit_id:
             return tag['ref'].split("refs/tags/")[-1]
+
+    return ""
 
 
 def retrieve_revision(commit_id, username, project, revision=None):

--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -66,8 +66,6 @@ def retrieve_tag(commit_id, username, project):
     tags_url = 'https://api.github.com/repos/%s/%s/git/refs/tags' % (
         username, project)
 
-    ## TODO: This might not do what is intended
-    ##   the tag SHA isn't the same thing as the commit it points
     tags_json = fetch_json(tags_url)
     for tag in tags_json:
         if tag['object']['sha'] == commit_id:


### PR DESCRIPTION
Return empty string for retrieve_tags for github commits.
Without this we can get errors about breaking the Null constraint on the tag field. 