### PR TITLE
Fix authentication helper so it works with newer versions of Django (Django 2+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.5"
       env: DJANGO_VERSION=2.1
 install:
-  - pip install flake8
+  - pip install flake8 mock
   - pip install -q Django==$DJANGO_VERSION
   - python setup.py install
 before_script:

--- a/codespeed/auth.py
+++ b/codespeed/auth.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_authenticated(request):
-    # NOTE: We do type check so we also support newer versions of Djando when
+    # NOTE: We do type check so we also support newer versions of Django when
     # is_authenticated and some other methods have been properties
     if isinstance(request.user.is_authenticated, (types.FunctionType,
                                                   types.MethodType)):

--- a/codespeed/tests/test_auth.py
+++ b/codespeed/tests/test_auth.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+import mock
+
+from django.test import TestCase, override_settings
+from django.http import HttpResponse
+from django.contrib.auth.models import AnonymousUser
+
+from codespeed.auth import basic_auth_required
+
+
+@override_settings(ALLOW_ANONYMOUS_POST=False)
+class AuthModuleTestCase(TestCase):
+    @override_settings(ALLOW_ANONYMOUS_POST=True)
+    def test_allow_anonymous_post_is_true(self):
+        wrapped_function = mock.Mock()
+        wrapped_function.__name__ = 'mock'
+        wrapped_function.return_value = 'success'
+
+        request = mock.Mock()
+        request.user = AnonymousUser()
+        request.META = {}
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertEqual(wrapped_function.call_count, 1)
+        self.assertEqual(res, 'success')
+
+    def test_basic_auth_required_django_pre_2_0_succesful_auth(self):
+        # request.user.is_authenticated is a method (pre Django 2.0)
+        user = mock.Mock()
+        user.is_authenticated = lambda: True
+
+        request = mock.Mock()
+        request.user = user
+
+        wrapped_function = mock.Mock()
+        wrapped_function.__name__ = 'mock'
+        wrapped_function.return_value = 'success'
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertEqual(wrapped_function.call_count, 1)
+        self.assertEqual(res, 'success')
+
+    def test_basic_auth_required_django_pre_2_0_failed_auth(self):
+        # request.user.is_authenticated is a method (pre Django 2.0)
+        user = mock.Mock()
+        user.is_authenticated = lambda: False
+
+        request = mock.Mock()
+        request.user = user
+        request.META = {}
+
+        wrapped_function = mock.Mock()
+        wrapped_function.__name__ = 'mock'
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertTrue(isinstance(res, HttpResponse))
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(wrapped_function.call_count, 0)
+
+        # Also test with actual AnonymousUser class which will have different
+        # implementation under different Django versions
+        request.user = AnonymousUser()
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertTrue(isinstance(res, HttpResponse))
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(wrapped_function.call_count, 0)
+
+    def test_basic_auth_required_django_post_2_0_successful_auth(self):
+        # request.user.is_authenticated is a property (post Django 2.0)
+        user = mock.Mock()
+        user.is_authenticated = True
+
+        request = mock.Mock()
+        request.user = user
+
+        wrapped_function = mock.Mock()
+        wrapped_function.__name__ = 'mock'
+        wrapped_function.return_value = 'success'
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertEqual(wrapped_function.call_count, 1)
+        self.assertEqual(res, 'success')
+
+    def test_basic_auth_required_django_post_2_0_failed_auth(self):
+        # request.user.is_authenticated is a property (post Django 2.0)
+        user = mock.Mock()
+        user.is_authenticated = False
+
+        request = mock.Mock()
+        request.user = user
+        request.META = {}
+
+        wrapped_function = mock.Mock()
+        wrapped_function.__name__ = 'mock'
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertTrue(isinstance(res, HttpResponse))
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(wrapped_function.call_count, 0)
+
+        # Also test with actual AnonymousUser class which will have different
+        # implementation under different Django versions
+        request.user = AnonymousUser()
+
+        res = basic_auth_required()(wrapped_function)(request=request)
+        self.assertTrue(isinstance(res, HttpResponse))
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(wrapped_function.call_count, 0)


### PR DESCRIPTION
I installed recommended version of Django (aka one which is specified in ``requirements.txt``), yet the ``/result/add/json/`` API endpoint returns an error when enabling authentication for that API endpoint (setting ``ALLOW_ANONYMOUS_POST`` config value to ``False``).

Here is the error / exception:

```bash
Traceback (most recent call last):
  File "/home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages/django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages/codespeed/auth.py", line 36, in _decorator
    elif hasattr(request, 'user') and request.user.is_authenticated():
TypeError: 'bool' object is not callable
"POST /result/add/json/ HTTP/1.1" 500 86983
```

Environment:

```bash
$ python --version
Python 3.7.6
$ pip show django
Name: Django
Version: 2.1.15
Summary: A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
Home-page: https://www.djangoproject.com/
Author: Django Software Foundation
Author-email: foundation@djangoproject.com
License: BSD
Location: /home/kami/.virtualenvs/codespeed-py3/lib/python3.7/site-packages
Requires: pytz
Required-by: codespeed
```
Looking at the Django changelog, this behavior (method to attribute / property) changed in Django 2 which is installed by CodeSpeed by default (as per ``requirements.txt``).

I assume this issue was never caught because no one who had authentication enabled ran CodeSpeed under Django 2+(?).

This pull request updates the authentication helper so it works with both versions of Django - one where that variable is a method (old versions) and one where it's a property (newer versions).

## TODO

- [x] Tests