### PR TITLE
Use a correct path to the static file (fix issue with /timeline page not loading)

### DIFF
--- a/codespeed/templates/codespeed/timeline.html
+++ b/codespeed/templates/codespeed/timeline.html
@@ -6,7 +6,7 @@
 
 {% block extra_head %}
 {{ block.super }}
-  <link rel="stylesheet" type="text/css" href="{% static '/css/timeline.css' %}" />
+  <link rel="stylesheet" type="text/css" href="{% static 'css/timeline.css' %}" />
   <link rel="stylesheet" type="text/css" href="{% static 'js/jqplot/jquery.jqplot.min.css' %}" />
 {% endblock %}
 


### PR DESCRIPTION
I noticed that while running on Heroku (or locally using whitenoise static file middleware), I receive the following error and the ``/timeline`` page fails to load.

```bash
2020-02-13T15:00:56.513458+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/django/templatetags/static.py", line 118, in handle_simple
2020-02-13T15:00:56.513458+00:00 app[web.1]: return staticfiles_storage.url(path)
2020-02-13T15:00:56.513459+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/django/contrib/staticfiles/storage.py", line 152, in url
2020-02-13T15:00:56.513467+00:00 app[web.1]: return self._url(self.stored_name, name, force)
2020-02-13T15:00:56.513468+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/django/contrib/staticfiles/storage.py", line 131, in _url
2020-02-13T15:00:56.513468+00:00 app[web.1]: hashed_name = hashed_name_func(*args)
2020-02-13T15:00:56.513469+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/django/contrib/staticfiles/storage.py", line 419, in stored_name
2020-02-13T15:00:56.513470+00:00 app[web.1]: raise ValueError("Missing staticfiles manifest entry for '%s'" % clean_name)
2020-02-13T15:00:56.513471+00:00 app[web.1]: ValueError: Missing staticfiles manifest entry for '/css/timeline.css'
2020-02-13T15:00:56.514385+00:00 app[web.1]: 10.51.131.88 - foo [13/Feb/2020:07:00:56 -0800] "GET /timeline/ HTT
```

It turns out the issue is related to the template file using incorrect path (the path should be relative, same as other paths).

I confirmed this fix works correctly.

Keep in mind that this issue would only manifest itself when running with ``DEBUG = False`` and using whitenoise middleware (http://whitenoise.evans.io/en/stable/).