### PR TITLE
Support authenticated Github API requests

### DIFF
--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -11,13 +11,16 @@ import logging
 try:
     # Python 3
     from urllib.request import urlopen
+    from urllib.request import Request
 except ImportError:
     # Python 2
-    from urllib import urlopen
+    from urllib2 import urlopen
+    from urllib2 import Request
 import re
 import json
 
 import isodate
+from django.conf import settings
 from django.core.cache import cache
 
 from .exceptions import CommitLogError
@@ -42,8 +45,17 @@ def fetch_json(url):
     json_obj = cache.get(url)
 
     if json_obj is None:
+        github_oauth_token = getattr(settings, 'GITHUB_OAUTH_TOKEN', None)
+
+        if github_oauth_token:
+            headers = {'Authorization': 'token %s' % (github_oauth_token)}
+        else:
+            headers = {}
+
+        request = Request(url=url, headers=headers)
+
         try:
-            json_obj = json.load(urlopen(url))
+            json_obj = json.load(urlopen(request))
         except IOError as e:
             logger.exception("Unable to load %s: %s",
                              url, e, exc_info=True)

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -83,3 +83,7 @@ USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 ALLOW_ANONYMOUS_POST = True  # Whether anonymous users can post results
 REQUIRE_SECURE_AUTH = True  # Whether auth needs to be over a secure channel
+
+GITHUB_OAUTH_TOKEN = None  # Github oAuth token to use when using Github repo type. If not
+                           # specified, it will utilize unauthenticated requests which have
+                           # low rate limits.


### PR DESCRIPTION
This pull request updates the code so it supports oAuth token authenticated requests to the Github API inside the Github repo provider.

## Background / Description

Right now Github provider utilizes non-authenticated Github API requests.

Those requests have a low rate limits set which means Github API will start returning 403 rate limit reached in case the rate limits have been hit (e.g. results for larger number commits are submitted in a short time frame).