### PR TITLE
Support timezone aware datetime objects with Github provider

### DIFF
--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -19,6 +19,7 @@ import json
 
 import isodate
 from django.core.cache import cache
+from django.conf import settings
 
 from .exceptions import CommitLogError
 
@@ -91,11 +92,13 @@ def retrieve_revision(commit_id, username, project, revision=None):
     if revision:
         # Overwrite any existing data we might have for this revision since
         # we never want our records to be out of sync with the actual VCS:
-
-        # We need to convert the timezone-aware date to a naive (i.e.
-        # timezone-less) date in UTC to avoid killing MySQL:
-        revision.date = date.astimezone(
-            isodate.tzinfo.Utc()).replace(tzinfo=None)
+        if not getattr(settings, 'USE_TZ_AWARE_DATES', False):
+            # We need to convert the timezone-aware date to a naive (i.e.
+            # timezone-less) date in UTC to avoid killing MySQL:
+            logger.debug('USE_TZ_AWARE_DATES setting is set to False, '
+                         'converting datetime object to a naive one')
+            revision.date = date.astimezone(
+                isodate.tzinfo.Utc()).replace(tzinfo=None)
         revision.author = commit_json['author']['name']
         revision.message = commit_json['message']
         revision.full_clean()

--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -20,7 +20,6 @@ import re
 import json
 
 import isodate
-from django.conf import settings
 from django.core.cache import cache
 from django.conf import settings
 

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -83,3 +83,6 @@ USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 ALLOW_ANONYMOUS_POST = True  # Whether anonymous users can post results
 REQUIRE_SECURE_AUTH = True  # Whether auth needs to be over a secure channel
+
+US_TZ_AWARE_DATES = False  # True to use timezone aware datetime objects with Github provider.
+                           # NOTE: Some database backends may not support tz aware dates.


### PR DESCRIPTION
This pull request adds new ``US_TZ_AWARE_DATES`` setting, which when set ``True``, updates the Github provider code to support timezone aware datetime objects.

For backward compatibility reasons, it defaults to ``False``.

## Background

Currently, if you use Github provider and have ``USE_TZ`` config option set to ``True``, incorrect dates will be displayed in the CodeSpeed dashboard.

The reason for that is that currently the Github provider code strips time zone info and makes datetime objects naive (aka not timezone aware). This means that datetime objects in the database carry no timezone info so all the timezone aware template functions will return invalid date.

This basically means that right now you can only use ``USE_TZ=False`` and UTC dates everywhere with the Github provider.