### PR TITLE
Make sure comparison view works correctly when a default VCS branch is not called "default"

### DIFF
--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from codespeed.models import Project, Executable, Branch, Revision
 from codespeed.views import getbaselineexecutables
+from codespeed.views import getcomparisonexes
 
 
 class TestGetBaselineExecutables(TestCase):
@@ -38,3 +39,101 @@ class TestGetBaselineExecutables(TestCase):
         Revision.objects.create(commitid='3', branch=self.branch)
         result = getbaselineexecutables()
         self.assertEqual(len(result), 3)
+
+
+class TestGetComparisonExes(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name='Test')
+        self.executable_1 = Executable.objects.create(
+            name='TestExecutable1', project=self.project)
+        self.executable_2 = Executable.objects.create(
+            name='TestExecutable2', project=self.project)
+        self.branch_master = Branch.objects.create(name='master',
+                                                   project=self.project)
+        self.branch_custom = Branch.objects.create(name='custom',
+                                                   project=self.project)
+
+        self.revision_1_master = Revision.objects.create(
+            branch=self.branch_master, commitid='1')
+        self.revision_1_custom = Revision.objects.create(
+            branch=self.branch_custom, commitid='1')
+
+    def test_get_comparisionexes_master_default_branch(self):
+        # Standard "master" default branch is used
+        self.project.default_branch = 'master'
+        self.project.save()
+
+        executables, exe_keys = getcomparisonexes()
+        self.assertEqual(len(executables), 1)
+        self.assertEqual(len(executables[self.project]), 4)
+        self.assertEqual(len(exe_keys), 4)
+
+        self.assertEqual(executables[self.project][0]['executable'],
+                         self.executable_1)
+        self.assertEqual(executables[self.project][0]['revision'],
+                         self.revision_1_master)
+        self.assertEqual(executables[self.project][0]['key'],
+                         '1+L+master')
+        self.assertEqual(executables[self.project][0]['name'],
+                         'TestExecutable1 latest')
+        self.assertEqual(executables[self.project][0]['revision'],
+                         self.revision_1_master)
+
+        self.assertEqual(executables[self.project][1]['key'],
+                         '2+L+master')
+        self.assertEqual(executables[self.project][1]['name'],
+                         'TestExecutable2 latest')
+
+        self.assertEqual(executables[self.project][2]['key'],
+                         '1+L+custom')
+        self.assertEqual(executables[self.project][2]['name'],
+                         'TestExecutable1 latest in branch \'custom\'')
+
+        self.assertEqual(executables[self.project][3]['key'],
+                         '2+L+custom')
+        self.assertEqual(executables[self.project][3]['name'],
+                         'TestExecutable2 latest in branch \'custom\'')
+
+        self.assertEqual(exe_keys[0], '1+L+master')
+        self.assertEqual(exe_keys[1], '2+L+master')
+
+    def test_get_comparisionexes_custom_default_branch(self):
+        # Custom default branch is used
+        self.project.default_branch = 'custom'
+        self.project.save()
+
+        executables, exe_keys = getcomparisonexes()
+        self.assertEqual(len(executables), 1)
+        self.assertEqual(len(executables[self.project]), 4)
+        self.assertEqual(len(exe_keys), 4)
+
+        self.assertEqual(executables[self.project][0]['executable'],
+                         self.executable_1)
+        self.assertEqual(executables[self.project][0]['revision'],
+                         self.revision_1_master)
+        self.assertEqual(executables[self.project][0]['key'],
+                         '1+L+master')
+        self.assertEqual(executables[self.project][0]['name'],
+                         'TestExecutable1 latest in branch \'master\'')
+        self.assertEqual(executables[self.project][0]['revision'],
+                         self.revision_1_master)
+
+        self.assertEqual(executables[self.project][1]['key'],
+                         '2+L+master')
+        self.assertEqual(executables[self.project][1]['name'],
+                         'TestExecutable2 latest in branch \'master\'')
+
+        self.assertEqual(executables[self.project][2]['key'],
+                         '1+L+custom')
+        self.assertEqual(executables[self.project][2]['name'],
+                         'TestExecutable1 latest')
+
+        self.assertEqual(executables[self.project][3]['key'],
+                         '2+L+custom')
+        self.assertEqual(executables[self.project][3]['name'],
+                         'TestExecutable2 latest')
+
+        self.assertEqual(exe_keys[0], '1+L+master')
+        self.assertEqual(exe_keys[1], '2+L+master')
+        self.assertEqual(exe_keys[2], '1+L+custom')
+        self.assertEqual(exe_keys[3], '2+L+custom')

--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -141,7 +141,7 @@ class TestGetComparisonExes(TestCase):
         self.assertEqual(exe_keys[2], '1+L+custom')
         self.assertEqual(exe_keys[3], '2+L+custom')
 
-        
+
 class UtilityFunctionsTestCase(TestCase):
     @override_settings(TIMELINE_EXECUTABLE_NAME_MAX_LEN=22)
     def test_get_sanitized_executable_name_for_timeline_view(self):

--- a/codespeed/views.py
+++ b/codespeed/views.py
@@ -225,7 +225,7 @@ def comparison(request):
                 else:
                     rev = Revision.objects.get(commitid=rev)
                     key += str(rev.id)
-                key += "+default"
+                key += "+%s" % (exe.project.default_branch)
                 if key in exekeys:
                     checkedexecutables.append(key)
                 else:

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -138,7 +138,7 @@ def getcomparisonexes():
                     if len(exestring) > maxlen:
                         exestring = str(exe)[0:maxlen] + "..."
                     name = exestring + " latest"
-                    if branch.name != 'default':
+                    if branch.name != proj.default_branch:
                         name += " in branch '" + branch.name + "'"
                     key = str(exe.id) + "+L+" + branch.name
                     executablekeys.append(key)


### PR DESCRIPTION
I tried to get ``COMP_EXECUTABLE`` setting to work with the following values, but It didn't appear to work:

```python
COMP_EXECUTABLES = [
    ('Python 2.7.17 - idle conf 1', 'L'),
    ('Python 3.5.9 - idle conf 1', 'L'),
    ('Python 2.7.17 - loaded conf 1', 'L'),
    ('Python 3.5.9 - loaded conf 2', 'L'),
]
```

After digging into the code, I noticed that the code hard codes the default branch value name to ``default``.

This obviously won't work when a default branch is not called ``default``. I assume this ``default`` value is a carry-over / legacy from Mercurial support (please correct me if I'm missing or misunderstanding something)...

---

In this pull request, I updated it to use ``default_branch`` value of the ``Project`` model.

I believe this is a correct change and I tested it with a project where value of ``default_branch`` is ``performance_tracking`` and it works correctly.

With this change, name in the left "Executables" select box menu will now also be correct and won't include ``... in branch ...`` part when a default branch is used.

Here is an example with the same ``COMP_EXECUTABLES`` setting value and ``Project.default_branch`` being set to ``performance_tracking``.

Before:

![Screenshot from 2020-02-17 16-27-45](https://user-images.githubusercontent.com/125088/74667601-da2b2080-51a3-11ea-9ebc-235bdb4e2338.png)

After:

![Screenshot from 2020-02-17 16-32-02](https://user-images.githubusercontent.com/125088/74667622-e616e280-51a3-11ea-8a27-85d709b15b82.png)


## TODO

- [x] Tests

