### PR TITLE
Make maximum length for executable names in the sidebar configurable

### DIFF
--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -78,6 +78,13 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
 
+TIMELINE_EXECUTABLE_NAME_MAX_LEN = 22  # Maximum length of the executable name used in the
+                                       # Changes and Timeline view. If the name is longer, the name
+                                       # will be truncated and "..." will be added at the end.
+
+COMPARISON_EXECUTABLE_NAME_MAX_LEN = 20  # Maximum length of the executable name  used in the
+                                         # Coomparison view. If the name is longer, the name
+
 USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 

--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase
+from django.test import override_settings
 
 from codespeed.models import Project, Executable, Branch, Revision
 from codespeed.views import getbaselineexecutables
+from codespeed.views_data import get_sanitized_executable_name_for_timeline_view
+from codespeed.views_data import get_sanitized_executable_name_for_comparison_view
 
 
 class TestGetBaselineExecutables(TestCase):
@@ -38,3 +41,25 @@ class TestGetBaselineExecutables(TestCase):
         Revision.objects.create(commitid='3', branch=self.branch)
         result = getbaselineexecutables()
         self.assertEqual(len(result), 3)
+
+
+class UtilityFunctionsTestCase(TestCase):
+    @override_settings(TIMELINE_EXECUTABLE_NAME_MAX_LEN=22)
+    def test_get_sanitized_executable_name_for_timeline_view(self):
+        executable = Executable(name='a' * 22)
+        name = get_sanitized_executable_name_for_timeline_view(executable)
+        self.assertEqual(name, 'a' * 22)
+
+        executable = Executable(name='a' * 25)
+        name = get_sanitized_executable_name_for_timeline_view(executable)
+        self.assertEqual(name, 'a' * 22 + '...')
+
+    @override_settings(COMPARISON_EXECUTABLE_NAME_MAX_LEN=20)
+    def test_get_sanitized_executable_name_for_comparision_view(self):
+        executable = Executable(name='b' * 20)
+        name = get_sanitized_executable_name_for_comparison_view(executable)
+        self.assertEqual(name, 'b' * 20)
+
+        executable = Executable(name='b' * 25)
+        name = get_sanitized_executable_name_for_comparison_view(executable)
+        self.assertEqual(name, 'b' * 20 + '...')

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -58,13 +58,10 @@ def getbaselineexecutables():
     }]
     executables = Executable.objects.select_related('project')
     revs = Revision.objects.exclude(tag="").select_related('branch__project')
-    maxlen = getattr(settings, 'TIMELINE_EXECUTABLE_NAME_MAX_LEN', 20)
     for rev in revs:
         # Add executables that correspond to each tagged revision.
         for exe in [e for e in executables if e.project == rev.branch.project]:
-            exestring = str(exe)
-            if len(exestring) > maxlen:
-                exestring = str(exe)[0:maxlen] + "..."
+            exestring = get_sanitized_executable_name_for_timeline_view(exe)
             name = exestring + " " + rev.tag
             key = str(exe.id) + "+" + str(rev.id)
             baseline.append({
@@ -116,7 +113,6 @@ def getcomparisonexes():
     for proj in Project.objects.all():
         executables = []
         executablekeys = []
-        maxlen = getattr(settings, 'COMPARISON_EXECUTABLE_NAME_MAX_LEN', 20)
         # add all tagged revs for any project
         for exe in baselines:
             if exe['key'] != "none" and exe['executable'].project == proj:
@@ -134,9 +130,7 @@ def getcomparisonexes():
             # because we already added tagged revisions
             if rev.tag == "":
                 for exe in Executable.objects.filter(project=proj):
-                    exestring = str(exe)
-                    if len(exestring) > maxlen:
-                        exestring = str(exe)[0:maxlen] + "..."
+                    exestring = get_sanitized_executable_name_for_comparison_view(exe)
                     name = exestring + " latest"
                     if branch.name != 'default':
                         name += " in branch '" + branch.name + "'"
@@ -260,3 +254,47 @@ def get_stats_with_defaults(res):
     if res.q3 is not None:
         q3 = res.q3
     return q1, q3, val_max, val_min
+
+
+def get_sanitized_executable_name_for_timeline_view(executable):
+    """
+    Return sanitized executable name which is used in the sidebar in the
+    Timeline and Changes view.
+
+    If the name is longer than settings.TIMELINE_EXECUTABLE_NAME_MAX_LEN,
+    the name will be truncated to that length and "..." appended to it.
+
+    :param executable: Executable object.
+    :type executable: :class:``codespeed.models.Executable``
+
+    :return: ``str``
+    """
+    maxlen = getattr(settings, 'TIMELINE_EXECUTABLE_NAME_MAX_LEN', 20)
+
+    exestring = str(executable)
+    if len(exestring) > maxlen:
+        exestring = str(executable)[0:maxlen] + "..."
+
+    return exestring
+
+
+def get_sanitized_executable_name_for_comparison_view(executable):
+    """
+    Return sanitized executable name which is used in the sidebar in the
+    comparision view.
+
+    If the name is longer than settings.COMPARISON_EXECUTABLE_NAME_MAX_LEN,
+    the name will be truncated to that length and "..." appended to it.
+
+    :param executable: Executable object.
+    :type executable: :class:``codespeed.models.Executable``
+
+    :return: ``str``
+    """
+    maxlen = getattr(settings, 'COMPARISON_EXECUTABLE_NAME_MAX_LEN', 22)
+
+    exestring = str(executable)
+    if len(exestring) > maxlen:
+        exestring = str(executable)[0:maxlen] + "..."
+
+    return exestring

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -58,7 +58,7 @@ def getbaselineexecutables():
     }]
     executables = Executable.objects.select_related('project')
     revs = Revision.objects.exclude(tag="").select_related('branch__project')
-    maxlen = 22
+    maxlen = getattr(settings, 'TIMELINE_EXECUTABLE_NAME_MAX_LEN', 20)
     for rev in revs:
         # Add executables that correspond to each tagged revision.
         for exe in [e for e in executables if e.project == rev.branch.project]:
@@ -116,7 +116,7 @@ def getcomparisonexes():
     for proj in Project.objects.all():
         executables = []
         executablekeys = []
-        maxlen = 20
+        maxlen = getattr(settings, 'COMPARISON_EXECUTABLE_NAME_MAX_LEN', 20)
         # add all tagged revs for any project
         for exe in baselines:
             if exe['key'] != "none" and exe['executable'].project == proj:


### PR DESCRIPTION
This pull request makes maximum length values which are used for truncating long executable names in the sidebar in the Changes, Timeline and Comparison views configurable.

Right now those default to relatively small values which means that names might get truncated too early which may make those executable names indistinguishable at a glance when the same common prefix is used for all the executable names (e.g. ``Python 2.7.17 - conf 1, Python 2.7.17 - conf 2, etc. - in this scenarios, last part which is the unique would would get truncated).

I know there are other ways around that (e.g. not having a common prefix, etc.), but I still think it doesn't hurt to make those limits user configurable.

Another potentially complementary change would also be allowing user to decide how to truncate executable names - e.g. truncate at the end (current behavior) or in the middle (potential new behavior).