### PR TITLE
Allow user to configure which tags to display on the comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ COMP_EXECUTABLES = [
     ('myexe', 'L'),
 ]
 ```
+* `COMPARISON_COMMIT_TAGS: Defines a list of tags to display on the comparison page. This comes
+  handy when there are a lot of tags. It defaults to ``None`` which means display all the available
+  tags.
 
 ### VCS Provider Specific Settings
 

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -78,6 +78,10 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
 
+COMPARISON_TAGS = None  # List of tag names which should be included on the comparision page.
+                        # If this value is set to None, all the available tags will be included.
+                        # Empty list means no tags will be included.
+
 TIMELINE_EXECUTABLE_NAME_MAX_LEN = 22  # Maximum length of the executable name used in the
                                        # Changes and Timeline view. If the name is longer, the name
                                        # will be truncated and "..." will be added at the end.

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -78,12 +78,12 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
 
-COMPARISON_TAGS = None  # List of tag names which should be included in the executables list on
-                        # the comparision page.
-                        # This comes handy where project contains a lot of tags, but you only want
-                        # to list subset of them on the comparison page.
-                        # If this value is set to None (default value), all the available tags will
-                        # be included.
+COMPARISON_COMMIT_TAGS = None  # List of tag names which should be included in the executables list
+                               # on the comparision page.
+                               # This comes handy where project contains a lot of tags, but you only want
+                               # to list subset of them on the comparison page.
+                               # If this value is set to None (default value), all the available tags will
+                               # be included.
 
 TIMELINE_EXECUTABLE_NAME_MAX_LEN = 22  # Maximum length of the executable name used in the
                                        # Changes and Timeline view. If the name is longer, the name

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -78,9 +78,12 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
 
-COMPARISON_TAGS = None  # List of tag names which should be included on the comparision page.
-                        # If this value is set to None, all the available tags will be included.
-                        # Empty list means no tags will be included.
+COMPARISON_TAGS = None  # List of tag names which should be included in the executables list on
+                        # the comparision page.
+                        # This comes handy where project contains a lot of tags, but you only want
+                        # to list subset of them on the comparison page.
+                        # If this value is set to None (default value), all the available tags will
+                        # be included.
 
 TIMELINE_EXECUTABLE_NAME_MAX_LEN = 22  # Maximum length of the executable name used in the
                                        # Changes and Timeline view. If the name is longer, the name

--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -193,7 +193,7 @@ class TestGetComparisonExes(TestCase):
         self.assertExecutablesListContainsRevision(executables[self.project], rev_v6)
 
         # Only a single tag should be included
-        with override_settings(COMPARISON_TAGS=['v4.0.0']):
+        with override_settings(COMPARISON_COMMIT_TAGS=['v4.0.0']):
             executables, exe_keys = getcomparisonexes()
             self.assertEqual(len(executables), 1)
             self.assertEqual(len(executables[self.project]), 2 * 2 + 2 * 1)
@@ -207,7 +207,7 @@ class TestGetComparisonExes(TestCase):
                 executables[self.project], rev_v6)
 
         # No tags should be included
-        with override_settings(COMPARISON_TAGS=[]):
+        with override_settings(COMPARISON_COMMIT_TAGS=[]):
             executables, exe_keys = getcomparisonexes()
             self.assertEqual(len(executables), 1)
             self.assertEqual(len(executables[self.project]), 2 * 2)

--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -61,7 +61,7 @@ class TestGetComparisonExes(TestCase):
         self.revision_1_custom = Revision.objects.create(
             branch=self.branch_custom, commitid='1')
 
-    def test_get_comparisionexes_master_default_branch(self):
+    def test_get_comparisonexes_master_default_branch(self):
         # Standard "master" default branch is used
         self.project.default_branch = 'master'
         self.project.save()
@@ -100,7 +100,7 @@ class TestGetComparisonExes(TestCase):
         self.assertEqual(exe_keys[0], '1+L+master')
         self.assertEqual(exe_keys[1], '2+L+master')
 
-    def test_get_comparisionexes_custom_default_branch(self):
+    def test_get_comparisonexes_custom_default_branch(self):
         # Custom default branch is used
         self.project.default_branch = 'custom'
         self.project.save()
@@ -141,7 +141,7 @@ class TestGetComparisonExes(TestCase):
         self.assertEqual(exe_keys[2], '1+L+custom')
         self.assertEqual(exe_keys[3], '2+L+custom')
 
-    def test_get_comparisionexes_branch_filtering(self):
+    def test_get_comparisonexes_branch_filtering(self):
         # branch1 and branch3 have display_on_comparison_page flag set to False
         # so they shouldn't be included in the result
         branch1 = Branch.objects.create(name='branch1', project=self.project,
@@ -173,7 +173,7 @@ class TestGetComparisonExes(TestCase):
         for index, exe_key in enumerate(expected_exe_keys):
             self.assertEqual(executables[self.project][index]['key'], exe_key)
 
-    def test_get_comparisionexes_tag_name_filtering(self):
+    def test_get_comparisonexes_tag_name_filtering(self):
         # Insert some mock revisions with tags
         rev_v4 = Revision.objects.create(
             branch=self.branch_master, commitid='4', tag='v4.0.0')
@@ -250,7 +250,7 @@ class UtilityFunctionsTestCase(TestCase):
         self.assertEqual(name, 'a' * 22 + '...')
 
     @override_settings(COMPARISON_EXECUTABLE_NAME_MAX_LEN=20)
-    def test_get_sanitized_executable_name_for_comparision_view(self):
+    def test_get_sanitized_executable_name_for_comparison_view(self):
         executable = Executable(name='b' * 20)
         name = get_sanitized_executable_name_for_comparison_view(executable)
         self.assertEqual(name, 'b' * 20)

--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -199,9 +199,12 @@ class TestGetComparisonExes(TestCase):
             self.assertEqual(len(executables[self.project]), 2 * 2 + 2 * 1)
             self.assertEqual(len(exe_keys), 2 * 2 + 2 * 1)
 
-            self.assertExecutablesListContainsRevision(executables[self.project], rev_v4)
-            self.assertExecutablesListDoesntContainRevision(executables[self.project], rev_v5)
-            self.assertExecutablesListDoesntContainRevision(executables[self.project], rev_v6)
+            self.assertExecutablesListContainsRevision(
+                executables[self.project], rev_v4)
+            self.assertExecutablesListDoesntContainRevision(
+                executables[self.project], rev_v5)
+            self.assertExecutablesListDoesntContainRevision(
+                executables[self.project], rev_v6)
 
         # No tags should be included
         with override_settings(COMPARISON_TAGS=[]):
@@ -210,9 +213,12 @@ class TestGetComparisonExes(TestCase):
             self.assertEqual(len(executables[self.project]), 2 * 2)
             self.assertEqual(len(exe_keys), 2 * 2)
 
-            self.assertExecutablesListDoesntContainRevision(executables[self.project], rev_v4)
-            self.assertExecutablesListDoesntContainRevision(executables[self.project], rev_v5)
-            self.assertExecutablesListDoesntContainRevision(executables[self.project], rev_v6)
+            self.assertExecutablesListDoesntContainRevision(
+                executables[self.project], rev_v4)
+            self.assertExecutablesListDoesntContainRevision(
+                executables[self.project], rev_v5)
+            self.assertExecutablesListDoesntContainRevision(
+                executables[self.project], rev_v6)
 
     def assertExecutablesListContainsRevision(self, executables, revision):
         found = self._executable_list_contains_revision(executables=executables,
@@ -220,7 +226,7 @@ class TestGetComparisonExes(TestCase):
 
         if not found:
             self.assertFalse("Didn't find revision \"%s\" in executable list \"%s\"" %
-                            (str(revision), str(executables)))
+                             (str(revision), str(executables)))
 
     def assertExecutablesListDoesntContainRevision(self, executables, revision):
         found = self._executable_list_contains_revision(executables=executables,
@@ -228,7 +234,7 @@ class TestGetComparisonExes(TestCase):
 
         if found:
             self.assertFalse("Found revision \"%s\", but didn't expect it" %
-                            (str(revision)))
+                             (str(revision)))
 
     def _executable_list_contains_revision(self, executables, revision):
         for executable in executables:

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -296,7 +296,7 @@ def get_sanitized_executable_name_for_timeline_view(executable):
 def get_sanitized_executable_name_for_comparison_view(executable):
     """
     Return sanitized executable name which is used in the sidebar in the
-    comparision view.
+    comparison view.
 
     If the name is longer than settings.COMPARISON_EXECUTABLE_NAME_MAX_LEN,
     the name will be truncated to that length and "..." appended to it.

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -119,11 +119,11 @@ def getdefaultexecutable():
 
 
 def getcomparisonexes():
-    comparison_tags = getattr(settings, 'COMPARISON_TAGS', None)
+    comparison_commit_tags = getattr(settings, 'COMPARISON_COMMIT_TAGS', None)
 
     all_executables = {}
     exekeys = []
-    baselines = getbaselineexecutables(include_tags=comparison_tags)
+    baselines = getbaselineexecutables(include_tags=comparison_commit_tags)
 
     for proj in Project.objects.all():
         executables = []

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -51,8 +51,8 @@ def get_default_environment(enviros, data, multi=False):
 
 def getbaselineexecutables(include_tags=None):
     """
-    :param include_tags: A list of tags to include in the result. If not specified, it will
-                        include all the available tags.
+    :param include_tags: A list of tags to include in the result. If set to
+                         None,, it will include all the available tags.
     :type include_tags: ``list``
     """
     baseline = [{


### PR DESCRIPTION
This pull request adds new ``COMPARISON_TAGS`` setting which allows user to configure which tags to include in the executables list on the comparison page.

This comes handy in scenario where a project contains a lot of tags, but you only want to include subset of them on a comparison page.

For backward compatibility reasons, default value is ``None`` which means include all the tags (same as the previous / existing behavior).

## Note On Settings Location

Right now some settings are configured via database models and other via settings.py. It would be nice to eventually come up with some convention on what setting to put where.

In reality, ``settings.py`` is a bit better from infrastructure as code perspective, but it's also possible to achieve the same end "infrastructure as code" result by version controlling model fixtures / migrations in the repository and inserting / running them on code deploy step.